### PR TITLE
update totalcross-maven-plugin version to 1.2.0

### DIFF
--- a/resources/pom.xml
+++ b/resources/pom.xml
@@ -53,7 +53,7 @@
             <plugin>
                 <groupId>com.totalcross</groupId>
                 <artifactId>totalcross-maven-plugin</artifactId>
-                <version>1.1.6</version>
+                <version>1.2.0</version>
                 <configuration>
                     <name>${project.name}</name>
                     <platforms>


### PR DESCRIPTION
this version of totalcross-maven-plugin has a bunch of improvement such as capability of easily package totalcross libraries and import them to projects.