### PR TITLE
Fixed bug where all platforms were unaligned generated

### DIFF
--- a/src/creator.ts
+++ b/src/creator.ts
@@ -74,10 +74,6 @@ exports.createNewProject = async function(context: vscode.ExtensionContext) {
     vscode.commands.executeCommand('vscode.openFolder', uri);
 };
 
-
-
-
-
 function setupFile(path: string, destPath: string, options: any) {
     return fs.copy(path, destPath)
         .then(async function() {
@@ -86,7 +82,7 @@ function setupFile(path: string, destPath: string, options: any) {
             if(options.platforms) {
                 for(let i = 0; i < options.platforms.length; i++) {
                     let platform = `<platform>${options.platforms[i]}</platform>`;
-                    if(i < 0 ) {
+                    if(i > 0) {
                         platform = '\t\t\t\t\t\t' + platform;
                     }
                     if(i < options.platforms.length - 1) {


### PR DESCRIPTION
When prompted to select all the supported platforms while creating a new project with the "Create new project" command, the pom.xml used to be generated with an unaligned platform list.

Before:
![prove_3_before](https://user-images.githubusercontent.com/26173202/136132324-2821c3df-bde7-4476-afb9-ab737f40ce10.png)

After:
![prove_1](https://user-images.githubusercontent.com/26173202/136132351-26c9d3eb-a972-4097-93e2-05da011eed75.png)

![prove_2](https://user-images.githubusercontent.com/26173202/136132353-089cd626-92f9-4472-acc5-6ce618336719.png)
