### PR TITLE
Modernize governance, validation, and dependency security

### DIFF
--- a/.agent/PLANS.md
+++ b/.agent/PLANS.md
@@ -1,0 +1,271 @@
+<!--
+Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Codex Execution Plans (ExecPlans)
+
+This document describes the requirements for an execution plan ("ExecPlan"), a design document that a coding agent can follow to deliver a working feature or system change. Treat the reader as a complete beginner to this repository: they have only the current working tree and the single ExecPlan file you provide. There is no memory of prior plans and no external context.
+
+## How to use ExecPlans and PLANS.md
+
+When authoring an executable specification (ExecPlan), follow PLANS.md _to the letter_. If it is not in your context, refresh your memory by reading the entire PLANS.md file. Be thorough in reading and re-reading source material to produce an accurate specification. When creating a specification, start from the skeleton and flesh it out as you do your research.
+
+When implementing an executable specification, do not prompt the user for "next steps"; simply proceed to the next milestone. Keep all sections up to date, and add or split entries in the progress list at every stopping point to affirmatively state the progress made and the next steps. Resolve ambiguities autonomously and commit frequently.
+
+When discussing an executable specification, record decisions in a log in the specification for posterity. It should be unambiguously clear why any change to the specification was made. ExecPlans are living documents, and it should always be possible to restart from _only_ the ExecPlan and no other work.
+
+When researching a design with challenging requirements or significant unknowns, use milestones to implement proofs of concept, toy implementations, or other focused experiments that validate whether the proposal is feasible. Read the source code of libraries by finding or acquiring them, research deeply, and include prototypes to guide the full implementation.
+
+At completion, preserve not only implementation evidence but also the factual material needed to communicate the work later. Every completed ExecPlan must contain a final `Editorial Report` that distinguishes the original intention from what was actually implemented and records the most useful material for a future technical article, release note, case study, or project update.
+
+## Requirements
+
+NON-NEGOTIABLE REQUIREMENTS:
+
+* Every ExecPlan must be fully self-contained. Self-contained means that, in its current form, it contains all knowledge and instructions needed for a novice to succeed.
+* Every ExecPlan is a living document. Contributors are required to revise it as progress is made, discoveries occur, and design decisions are finalized. Each revision must remain fully self-contained.
+* Every ExecPlan must enable a complete novice to implement the feature end-to-end without prior knowledge of this repository.
+* Every ExecPlan must produce demonstrably working behavior, not merely code changes that meet a narrow definition.
+* Every ExecPlan must define every term of art in plain language or avoid using it.
+* Every completed ExecPlan must contain a factual, self-contained `Editorial Report`. The report is part of the definition of done and must be updated if later work changes the final outcome.
+
+Purpose and intent come first. Begin by explaining, in a few sentences, why the work matters from a user's perspective: what someone can do after this change that they could not do before, and how to see it working. Then guide the reader through the exact steps to achieve that outcome, including what to edit, what to run, and what they should observe.
+
+The agent executing the plan can list files, read files, search, run the project, and run tests. It does not know prior context and cannot infer what was intended from earlier milestones. Repeat every assumption on which the work relies. Do not point to external blogs or documentation as a substitute for necessary context; embed the required knowledge in the plan in your own words. If an ExecPlan builds upon a prior ExecPlan and that file is checked in, incorporate it by reference. Otherwise, include all relevant context from the prior plan.
+
+The `Editorial Report` must be grounded in execution evidence. It must not present planned work as completed work, estimates as measurements, prototypes as production behavior, or hypotheses as conclusions. When a useful fact cannot be verified, state that it is unverified or omit it. Reference repository-relative paths, tests, commits, benchmarks, issue or pull-request identifiers, and concise output excerpts when they support the report.
+
+## Formatting
+
+Format and envelope are simple and strict. Each ExecPlan must be one single fenced code block labeled as `md` that begins and ends with triple backticks. Do not nest additional triple-backtick code fences inside it. When showing commands, transcripts, diffs, or code, present them as indented blocks within that single fence. Use indentation for clarity rather than nested fences.
+
+Use two newlines after every heading, use `#`, `##`, and subsequent heading levels correctly, and use valid Markdown syntax for ordered and unordered lists.
+
+When writing an ExecPlan to a Markdown file whose entire contents are the single ExecPlan, omit the outer triple backticks.
+
+Write in plain prose. Prefer sentences over lists. Avoid checklists, tables, and long enumerations unless prose would obscure the meaning. Checklists are permitted only in the `Progress` section, where they are mandatory. The `Editorial Report` may use short labeled entries because it is a factual handoff artifact, but each entry must remain explanatory rather than becoming an unannotated inventory.
+
+## Guidelines
+
+Self-containment and plain language are paramount. If you introduce a phrase that is not ordinary English, such as "daemon", "middleware", "RPC gateway", or "filter graph", define it immediately and explain how it manifests in this repository by naming relevant files, modules, or commands. Do not say "as defined previously" or "according to the architecture document." Include the needed explanation here, even when that repeats information.
+
+Avoid common failure modes. Do not rely on undefined jargon. Do not describe a feature so narrowly that the resulting code compiles but does nothing meaningful. Do not outsource key decisions to the reader. When ambiguity exists, resolve it in the plan and explain why that path was chosen. Err on the side of explaining user-visible effects and avoid over-specifying incidental implementation details.
+
+Anchor the plan with observable outcomes. State what the user can do after implementation, the commands to run, and the outputs they should see. Acceptance must be phrased as behavior a human can verify, such as "after starting the server, navigating to http://localhost:8080/health returns HTTP 200 with body OK", rather than an internal attribute such as "added a HealthCheck struct". If a change is internal, explain how its effect can still be demonstrated, for example through a test that fails before the change and passes afterward or through a scenario that exercises the new behavior.
+
+Specify repository context explicitly. Name files with full repository-relative paths, name functions and modules precisely, and describe where new files must be created. If touching multiple areas, include a short orientation paragraph explaining how those parts fit together. When running commands, show the working directory and exact command line. When outcomes depend on the environment, state the assumptions and provide alternatives when reasonable.
+
+Be idempotent and safe. Write steps so they can be run repeatedly without causing damage or drift. If a step can fail halfway, explain how to retry or adapt. If a migration or destructive operation is necessary, describe backups and safe fallback paths. Prefer additive, testable changes that can be validated incrementally.
+
+Validation is not optional. Include instructions to run tests, start the system when applicable, and observe useful behavior. Describe comprehensive testing for new features and capabilities. Include expected outputs and relevant failure messages so a novice can distinguish success from failure. Where possible, prove that the change is effective beyond compilation through an end-to-end scenario, CLI invocation, request and response, generated artifact, or another observable result. State the exact test commands appropriate to the project's toolchain and explain how to interpret the results.
+
+Capture evidence. When steps produce terminal output, short diffs, logs, benchmarks, screenshots, generated files, or other evidence, include concise examples in the plan. Prefer small excerpts that prove success over large output dumps.
+
+Capture editorial evidence as the work proceeds. When a discovery changes the implementation, a rejected alternative clarifies a trade-off, a benchmark produces a meaningful result, or an unexpected failure leads to a useful lesson, record it immediately in the living sections. The final `Editorial Report` should synthesize those records rather than reconstructing the project from memory at the end.
+
+## Milestones
+
+Milestones are narrative, not bureaucracy. If the work is divided into milestones, introduce each with a brief paragraph that describes its scope, what will exist at its end that did not exist before, the commands to run, and the acceptance criteria to observe. Keep the narrative readable as goal, work, result, and proof.
+
+Progress and milestones are distinct. Milestones tell the implementation story; `Progress` tracks granular work. Both must exist. Never abbreviate a milestone merely for brevity or omit details that could be crucial to a future implementation. Each milestone must be independently verifiable and incrementally implement the overall goal.
+
+The final milestone must include completion of the `Editorial Report`. It is not acceptable to mark the plan complete while leaving that section as a placeholder. The report may be written incrementally, but it must be reconciled with the final implementation, validation results, and `Outcomes & Retrospective` before completion.
+
+## Living plans and design decisions
+
+* ExecPlans are living documents. As key design decisions are made, update the plan to record both the decision and the reasoning behind it. Record all decisions in the `Decision Log`.
+* ExecPlans must contain and maintain a `Progress` section, a `Surprises & Discoveries` section, a `Decision Log`, an `Outcomes & Retrospective` section, and an `Editorial Report` section. These are not optional.
+* When optimizer behavior, performance trade-offs, unexpected bugs, portability limitations, compatibility constraints, or inverse and rollback semantics shape the approach, capture those observations in `Surprises & Discoveries` with concise evidence.
+* If the implementation changes course, document why in the `Decision Log` and reflect the implications in `Progress`.
+* At completion of a major task or the full plan, update `Outcomes & Retrospective` with what was achieved, what remains, and what was learned.
+* At completion of the full plan, finalize the `Editorial Report` from the actual implementation and validation evidence. Make clear which intended outcomes were delivered, changed, deferred, rejected, or remain uncertain.
+* If the plan is resumed after the report was first written, update the report so it continues to describe the final repository state rather than an earlier stopping point.
+
+## Editorial Report requirements
+
+The `Editorial Report` is a concise factual handoff for future communication. It is not itself a finished blog post and must not use promotional language unsupported by evidence. It must be understandable without access to chat history.
+
+The report must contain the following labeled subsections:
+
+### Editorial Summary
+
+Explain the engineering problem, why it mattered, and the final result in a few paragraphs. Describe the reader-visible or developer-visible consequence, not merely the files changed.
+
+### Original Plan versus Actual Outcome
+
+State what the plan initially intended and how the executed result differed. Identify work completed as planned, work whose design changed, work deferred, and work rejected. Explain the reasons for material differences.
+
+### What Changed
+
+Describe the significant changes with repository-relative paths and stable names for important components, APIs, build tasks, workflows, or artifacts. Focus on changes that help a future writer explain the system rather than exhaustively reproducing a diff.
+
+### Decisions and Trade-offs
+
+Summarize the most consequential decisions and alternatives considered. Explain why the selected approach was preferable under the project's constraints and identify meaningful costs or limitations it introduced.
+
+### Unexpected Problems and Discoveries
+
+Summarize the failures, incompatibilities, surprising behavior, or new understanding that materially shaped the result. Include concise supporting evidence or point to entries in `Surprises & Discoveries`.
+
+### Validation and Measurable Results
+
+List only results that were actually observed. Include exact test commands, relevant counts, benchmark conditions, artifact sizes, compatibility results, or before-and-after behavior when available. Explicitly state when no meaningful performance or size measurement was taken.
+
+### Useful Evidence and Examples
+
+Identify concise code excerpts, diffs, logs, screenshots, diagrams, commits, pull requests, issues, generated artifacts, or reproducible commands that would help support a future article. Do not paste large blobs; point to stable repository locations or include short evidence excerpts.
+
+### Limitations, Remaining Work, and Open Questions
+
+Describe what the implementation does not solve, known platform or compatibility limits, follow-up work, and questions that remain unresolved. Do not hide incomplete or negative results.
+
+### Possible Article Angles
+
+Suggest several technically honest article directions. Each angle should name the target reader, the central problem, and the useful takeaway. Prefer problem-oriented titles over product announcements. For example, prefer "Designing a rendering abstraction for CPU, OpenGL, Metal, and Vulkan" over "We added new graphics backends".
+
+### Suggested Narrative
+
+Provide a compact narrative sequence for the strongest article angle, normally covering the problem, constraints, alternatives, implementation path, unexpected difficulty, final design, evidence, limitations, and next step. This is an outline, not a polished article.
+
+### Claims Requiring Human Review
+
+List statements that may be sensitive, externally visible, historically uncertain, commercially significant, security-relevant, or insufficiently verified. If there are none, state that no special claims were identified, while still requiring normal editorial and technical review before publication.
+
+## Prototyping milestones and parallel implementations
+
+It is acceptable, and often encouraged, to include explicit prototyping milestones when they reduce risk in a larger change. Examples include adding a low-level operator to a dependency to validate feasibility or exploring two composition orders while measuring optimizer effects. Keep prototypes additive and testable. Clearly label the scope as prototyping, describe how to run and observe the result, and state the criteria for promoting or discarding the prototype.
+
+Prefer additive changes followed by removals that keep tests passing. Parallel implementations, such as keeping an adapter alongside an older path during migration, are appropriate when they reduce risk or allow validation to continue. Describe how to validate both paths and how to retire one safely.
+
+When working with multiple new libraries or feature areas, consider creating independent spikes that prove each external library or feature behaves as required before integrating them.
+
+## Skeleton of a Good ExecPlan
+
+# <Short, action-oriented description>
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, `Outcomes & Retrospective`, and `Editorial Report` must be kept up to date as work proceeds.
+
+If PLANS.md is checked into the repository, reference its repository-relative path here and state that this document must be maintained in accordance with it.
+
+## Purpose / Big Picture
+
+Explain in a few sentences what someone gains after this change and how they can see it working. State the user-visible or developer-visible behavior that will be enabled.
+
+## Progress
+
+Use a list with checkboxes to summarize granular steps. Every stopping point must be documented here, even if that requires splitting a partially completed task into completed and remaining portions. This section must always reflect the actual state of the work.
+
+- [x] (2025-10-01 13:00Z) Example completed step.
+- [ ] Example incomplete step.
+- [ ] Example partially completed step (completed: X; remaining: Y).
+- [ ] Finalize the Editorial Report from the completed implementation and validation evidence.
+
+Use timestamps to make the rate and sequence of progress visible.
+
+## Surprises & Discoveries
+
+Document unexpected behavior, bugs, optimizations, limitations, or insights discovered during implementation. Provide concise evidence.
+
+- Observation: …
+  Evidence: …
+
+## Decision Log
+
+Record every decision made while working on the plan in this format:
+
+- Decision: …
+  Rationale: …
+  Date/Author: …
+
+## Outcomes & Retrospective
+
+Summarize outcomes, gaps, and lessons learned at major milestones and at completion. Compare the result against the original purpose.
+
+## Editorial Report
+
+This section is mandatory at completion. Keep it factual, evidence-based, and synchronized with the final implementation.
+
+### Editorial Summary
+
+Describe the problem, its significance, and the final result.
+
+### Original Plan versus Actual Outcome
+
+Explain what was intended and what actually happened, including completed, changed, deferred, or rejected work.
+
+### What Changed
+
+Name the important repository-relative paths, components, APIs, workflows, and artifacts that changed.
+
+### Decisions and Trade-offs
+
+Summarize the consequential choices, alternatives, rationale, costs, and limitations.
+
+### Unexpected Problems and Discoveries
+
+Describe the difficulties and insights that materially affected the implementation, with concise evidence.
+
+### Validation and Measurable Results
+
+Record exact validation commands and only results that were actually observed.
+
+### Useful Evidence and Examples
+
+Point to concise supporting code, tests, logs, diffs, diagrams, screenshots, commits, pull requests, issues, or generated artifacts.
+
+### Limitations, Remaining Work, and Open Questions
+
+State what remains incomplete or unresolved and the known limits of the result.
+
+### Possible Article Angles
+
+Suggest problem-oriented article angles, identifying the target reader and useful takeaway for each.
+
+### Suggested Narrative
+
+Outline the strongest article as problem, constraints, alternatives, implementation, difficulty, result, evidence, limitations, and next step.
+
+### Claims Requiring Human Review
+
+Identify claims requiring special verification before publication, or state that none were identified beyond normal review.
+
+## Context and Orientation
+
+Describe the current state relevant to this task as if the reader knows nothing. Name key files and modules by full repository-relative path. Define every non-obvious term. Do not rely on prior plans or chat history.
+
+## Plan of Work
+
+Describe in prose the sequence of edits and additions. For every edit, name the file and location, such as the function or module, and explain what to insert or change. Keep it concrete and minimal.
+
+## Concrete Steps
+
+State exact commands to run and the working directory for each. When a command generates output, show a short expected transcript so the reader can compare. Update this section as the work proceeds.
+
+## Validation and Acceptance
+
+Describe how to start or exercise the system and what to observe. Phrase acceptance as behavior with specific inputs and outputs. When tests are involved, state the project command and the expected result, including which new test fails before the change and passes afterward when applicable.
+
+The plan is not complete until the final validation evidence has also been reconciled into `Outcomes & Retrospective` and the `Editorial Report`.
+
+## Idempotence and Recovery
+
+State which steps can be repeated safely. For risky steps, provide a safe retry, rollback, or restoration path. Keep the environment clean after completion.
+
+## Artifacts and Notes
+
+Include the most important transcripts, diffs, generated files, screenshots, diagrams, or snippets. Keep them concise and focused on proving success.
+
+## Interfaces and Dependencies
+
+Be prescriptive. Name the libraries, modules, and services to use and explain why. Specify the types, interfaces, traits, and function signatures that must exist at the end of the milestone. Prefer stable names and repository-relative paths.
+
+For example, in `crates/foo/planner.rs`, define:
+
+    pub trait Planner {
+        fn plan(&self, observed: &Observed) -> Vec<Action>;
+    }
+
+If this guidance is followed, a single stateless agent or a human novice can read an ExecPlan from top to bottom and produce a working, observable result while preserving enough trustworthy evidence for future communication. That is the bar: SELF-CONTAINED, SELF-SUFFICIENT, NOVICE-GUIDING, OUTCOME-FOCUSED, AND EDITORIALLY TRACEABLE.
+
+When revising a plan, ensure the changes are comprehensively reflected across all sections, including the living-document sections and the `Editorial Report`. Write a note at the bottom of the plan describing the revision and why it was made. ExecPlans must describe not only what changed but why, and completed plans must make clear what actually happened.

--- a/.agent/exec-plan-mit-to-apache-governance-refactor.md
+++ b/.agent/exec-plan-mit-to-apache-governance-refactor.md
@@ -65,7 +65,7 @@ The plan must not claim that code originally distributed under MIT retroactively
 - [x] (2026-07-15) Reopened the ExecPlan at the maintainer's request to correct dependency vulnerabilities; confirmed that the repository lacks a lockfile and therefore `npm audit` cannot produce a trustworthy dependency graph.
 - [x] (2026-07-15) Generated `package-lock.json` and audited the reproducible graph: 17 findings (2 critical, 4 high, 9 moderate, 2 low) came from request-related runtime dependencies, `node-ssh`, Mocha, TSLint, and their transitives.
 - [x] (2026-07-15) Applied the dependency security corrections and validated an installation from the lockfile: `npm audit` now reports 0 vulnerabilities; compilation, governance validation (15 tests), and the three-test VS Code integration suite pass.
-- [ ] Commit the security correction and reconcile its hash and evidence into the final outcome sections.
+- [x] (2026-07-15) Committed the security correction as `9cb6cd6` (`fix(security): remediate vulnerable dependencies`) and reconciled its evidence below.
 
 ## Surprises & Discoveries
 
@@ -273,8 +273,17 @@ No public extension command, runtime dependency, API, resource path, or
 platform behavior changed. Broader source reorganization and security-related
 cleanup were considered but rejected because the small codebase has sparse
 behavioral coverage and those changes were not necessary to make the baseline
-valid and buildable. npm reports 17 dependency vulnerabilities after the final
-install; dependency security modernization is a separate follow-up.
+valid and buildable.
+
+The resumed security milestone added `package-lock.json`, then reduced the
+reproducible `npm audit` result from 17 findings (including two critical) to
+zero. Commit `9cb6cd6` removes the abandoned request stack and its unused
+imports, replaces `totalcross-core-dev` metadata access with
+`src/maven-metadata.ts`, replaces `pom-parser`, upgrades `node-ssh` and Mocha,
+and removes unused TSLint. It also adds an audit script, CI audit step, lockfile
+validation, and one Maven metadata test. `npm ci --ignore-scripts`, `npm run
+audit`, compilation, 16 governance tests, and the three-test VS Code suite all
+passed.
 
 ## Editorial Report
 
@@ -291,6 +300,9 @@ The execution also restored a usable development verification path: compilation
 uses a compatible VS Code type definition package, and the extension tests run
 successfully from a VS Code-hosted development environment.
 
+The later security milestone makes that verification reproducible with a
+lockfile and keeps the audited npm graph free of known vulnerabilities.
+
 ### Original Plan versus Actual Outcome
 
 The governance transition, attribution documentation, header normalization,
@@ -298,7 +310,9 @@ validator, tests, CI, and logical baseline commit were delivered as planned.
 The code review found no safe structural reorganization worth manufacturing.
 Instead, it found two concrete build/test compatibility regressions caused by
 dependency and host-environment drift; those were resolved in two separately
-reviewable refactoring commits.
+reviewable refactoring commits. After the original plan completed, the
+maintainer requested vulnerability remediation; that resumed milestone replaced
+the vulnerable dependency chains and completed with a zero-finding audit.
 
 ### What Changed
 
@@ -313,7 +327,9 @@ headers were added to `src/`, first-party `resources/`, and `test.sh`.
 `package.json` pins the VS Code API type package and adopts
 `@vscode/test-electron`. `src/test/runTest.ts` clears an inherited process
 variable before launching VS Code so the integration application is not forced
-into Node mode.
+into Node mode. `package-lock.json` fixes the dependency graph,
+`src/maven-metadata.ts` replaces the request-based metadata helper, and the CI
+workflow runs `npm ci` plus `npm run audit` before governance checks.
 
 ### Decisions and Trade-offs
 
@@ -323,7 +339,9 @@ releases were retroactively relicensed. Header enforcement deliberately uses a
 small Python script and explicit path categories, trading automatic historical
 inference for readable, auditable rules. The maintained test package is kept on
 its 2.5 major line because its 3.0 declarations are incompatible with the
-project's TypeScript compiler.
+project's TypeScript compiler. The security fix avoids `npm audit fix --force`:
+it removes abandoned runtime dependencies and applies narrowly scoped npm
+overrides for Mocha's vulnerable transitives, validated by the test suite.
 
 ### Unexpected Problems and Discoveries
 
@@ -331,7 +349,10 @@ An unpinned VS Code type dependency resolved to 1.125.0, which TypeScript 3.9
 could not parse. The deprecated test wrapper then failed to launch a current
 macOS VS Code, and the maintained replacement initially inherited
 `ELECTRON_RUN_AS_NODE=1` from the host process. Removing that variable at the
-test launcher boundary produced a successful test run.
+test launcher boundary produced a successful test run. The security work then
+found that no lockfile existed, so the previous audit count could not be
+reproduced; adding one exposed the abandoned request stack as the source of the
+critical findings.
 
 ### Validation and Measurable Results
 
@@ -344,23 +365,26 @@ Observed successful commands were:
 
 The governance validator passed; 14 governance tests passed; compilation
 passed; and the VS Code integration run reported two passing tests and exit
-code 0. The final search found zero current-content occurrences of the obsolete
-contact address. No performance or artifact-size measurement was taken.
+code 0. After the security milestone, `npm ci --ignore-scripts` and `npm run
+audit` passed with zero audit findings; the governance suite grew to 16 tests
+and the integration run reported three passing tests. The final search found
+zero current-content occurrences of the obsolete contact address. No
+performance or artifact-size measurement was taken.
 
 ### Useful Evidence and Examples
 
-The three commits `ca549be`, `b7072bd`, and `d8dc0e6` separate the governance,
-build, and test work. `tools/check-repository-governance.py` and
+The four commits `ca549be`, `b7072bd`, `d8dc0e6`, and `9cb6cd6` separate the
+governance, build, test, and security work. `tools/check-repository-governance.py` and
 `tests/test_repository_governance.py` provide reproducible policy evidence.
-The final `npm test` transcript records the two passing extension tests.
+The final `npm test` transcript records the three passing extension tests, and
+`package-lock.json` provides the audited dependency graph.
 
 ### Limitations, Remaining Work, and Open Questions
 
 The authority for prospective relicensing follows the requested governance
-decision and was not independently verified with external legal records.
-The repository has no lockfile, so transitive dependencies can still drift.
-npm reports 17 vulnerabilities in the installed dependency tree; resolving
-them safely requires a dedicated dependency upgrade and compatibility review.
+decision and was not independently verified with external legal records. npm
+audit currently reports zero vulnerabilities for the lockfile, but audit data
+can change and the dependency graph should continue to be checked in CI.
 Existing extension tests remain minimal and do not characterize deployment,
 packaging, or project-creation behavior.
 
@@ -839,9 +863,13 @@ The plan is complete only when all applicable conditions are observable:
 - [x] Public API and compatibility impacts are documented.
 - [x] Full final build/tests pass.
 - [x] `git diff --check` passes.
-- [x] Working tree is clean after this plan-record commit.
+- [x] Working tree is clean after the current final plan-record commit.
 - [x] `Outcomes & Retrospective` is complete.
 
 Revision note (2026-07-15): recorded the completed governance transition,
 dependency and test-runner compatibility refactorings, observed validation
-results, remaining dependency-security work, and the final Editorial Report.
+results, and the final Editorial Report.
+
+Revision note (2026-07-15, resumed): added the maintainer-requested
+vulnerability remediation milestone, its reproducible audit baseline and zero
+finding result, the lockfile/CI enforcement, and commit `9cb6cd6`.

--- a/.agent/exec-plan-mit-to-apache-governance-refactor.md
+++ b/.agent/exec-plan-mit-to-apache-governance-refactor.md
@@ -1,0 +1,639 @@
+<!--
+Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Migrate project governance from MIT to Apache-2.0, correct authorship and maintenance attribution, then refactor in logical commits
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+This plan must be maintained in accordance with the repository's `.agent/PLANS.md`. If that file does not yet exist, create it in the first governance commit using the current OpenAI Codex ExecPlan conventions, and use this document as the initial plan executed under those rules.
+
+## Purpose / Big Picture
+
+The project currently uses the MIT license and contains historical authorship, maintenance, copyright, and contact information that must be updated without erasing legitimate historical attribution.
+
+The work has two deliberately separate phases:
+
+1. create one governance commit that changes the project license prospectively from MIT to Apache License 2.0, corrects repository-level authorship and maintenance metadata, removes the obsolete former project contact address, adds agent instructions and planning conventions, introduces deterministic validators, and normalizes first-party source headers according to the ownership period of each file;
+2. after the governance baseline is complete and validated, inspect the implementation and perform justified refactoring and reorganization, committing those changes in small, coherent, independently reviewable groups.
+
+After the first commit:
+
+- the repository license for new and modified project work is identified by `SPDX-License-Identifier: Apache-2.0`;
+- the original project is credited to Italo Yeltsin (`@ItaloYeltsin`);
+- Fabio Sobral (`@flsobral`) is identified as the sole current maintainer;
+- previously credited people remain visible in a historical contributors section, without being presented as current maintainers;
+- all occurrences of the obsolete former project contact address are removed from first-party project content and metadata where removal is legally and technically appropriate;
+- source files attributable to the original 2020–2021 TotalCross period retain that historical ownership and MIT licensing information;
+- source files attributable to the 2022–2026 Amalgam period use Amalgam copyright and Apache-2.0 licensing information;
+- third-party, vendored, generated, imported, or separately licensed files retain their authoritative notices;
+- repository documentation explains the license transition and the distinction between original creation, historical contribution, present maintenance, and copyright ownership;
+- contributors and agents can run one concise validation command locally, and CI runs the same checks;
+- `AGENTS.md` and `.agent/PLANS.md` define how coding agents must inspect, edit, validate, and commit changes in this repository.
+
+The plan must not claim that code originally distributed under MIT retroactively became Apache-2.0. The repository-level transition is prospective from the governance commit onward. Historical MIT notices must remain accurate where they apply.
+
+## Progress
+
+- [x] (2026-07-15) Read `.agent/PLANS.md` and this ExecPlan; no pre-existing `AGENTS.md`, contributor guide, or nested instruction file was tracked.
+- [x] (2026-07-15) Inspected local and remote Git history, `master`, tags, working tree, and commit conventions without rewriting history.
+- [x] (2026-07-15) Inventoried licensing, attribution, contact, source, build, and CI files.
+- [x] (2026-07-15) Searched the obsolete contact, attribution names, contributors, and license notices; the only current-content occurrence was in `README.md`, while historical Git metadata remains unchanged.
+- [x] (2026-07-15) Classified all `src/` and first-party `resources/` source/templates as historical MIT work; `resources/maven-metadata.xml` as generated; documentation/configuration/assets as metadata or excluded; and new governance tooling as Amalgam Apache-2.0 work. No mixed-history production file was found.
+- [x] (2026-07-15) Recorded historical contributors evidenced by Git or the previous README: Allan C, lucasgalvanini, Ricardo Braga, and @nmarquesin.
+- [x] (2026-07-15) Applied the requested prospective Apache-2.0 transition only to current/new work; Git history contains no Amalgam-era source modification that would require a mixed header.
+- [x] (2026-07-15) Defined and implemented canonical C-style, hash-style, XML, and shebang-preserving header validation.
+- [x] (2026-07-15) Created `AGENTS.md` and adopted the existing untracked `.agent/PLANS.md` as the repository planning convention.
+- [x] (2026-07-15) Updated `LICENSE`, `NOTICE`, `README.md`, `AUTHORS.md`, `CONTRIBUTING.md`, and `.github/CODEOWNERS`.
+- [x] (2026-07-15) Implemented `tools/check-repository-governance.py` with deterministic Git-based path handling and concise sorted diagnostics.
+- [x] (2026-07-15) Added 14 focused `unittest` cases, including headers, provenance exceptions, attribution, ordering, whitespace paths, shebangs, and XML declarations.
+- [x] (2026-07-15) Added `.github/workflows/governance-validation.yml` invoking the documented validator and test commands.
+- [x] (2026-07-15) Added historical MIT headers to 21 applicable `src/`, `resources/`, and shell files; generated Maven metadata remains untouched.
+- [x] (2026-07-15) Reviewed the governance diff; it contains attribution, licensing, planning, validation, CI, and header changes only.
+- [ ] Create the first governance commit.
+- [ ] Run the complete validation and focused build/test suite from the governance commit.
+- [ ] Inspect architecture, packages, modules, dependencies, naming, duplicated code, dead code, build structure, tests, and public APIs for refactoring opportunities.
+- [ ] Write proposed refactoring groups in `Decision Log` before changing code.
+- [ ] Implement refactoring in logical, independently buildable commits.
+- [ ] After each refactoring commit, run the smallest sufficient validation set and record meaningful findings.
+- [ ] Run the full supported build and test suite after the final refactoring commit.
+- [ ] Review the final commit sequence for accidental mixing of governance and implementation work.
+- [ ] Complete `Outcomes & Retrospective` with counts, commands, commit hashes, exceptions, and follow-up items.
+
+## Surprises & Discoveries
+
+Record repository-specific findings here as work proceeds.
+
+Important examples include:
+
+- a file includes contributions from both licensing periods and cannot be classified from its current header alone;
+- Git history contradicts the year or owner written in a header;
+- the MIT license text grants permissions that must remain available for historical releases;
+- Apache relicensing authority is incomplete or unclear for some contributor-owned code;
+- an email address occurs in a historical artifact, test fixture, patch, vendored file, or signed metadata where removing it would alter authoritative third-party or historical material;
+- contributor names appear only in Git history and not in repository documentation;
+- generated sources are checked in and require changes to their generator instead of direct edits;
+- source files have mandatory first lines such as shebangs, XML declarations, encoding declarations, or generated markers;
+- a refactor that appears cosmetic changes public API, binary compatibility, serialization, package names, resource paths, or platform behavior;
+- tests are missing for code that should be reorganized, requiring characterization tests before structural changes.
+
+Do not silently resolve legal, attribution, or historical ambiguity. Record the evidence, the chosen treatment, and any limitation.
+
+- Observation: All version-controlled production source and first-party templates have a first or last substantive Git change dated 2019-2021; the only post-2021 commit changes `CHANGELOG.md`.
+  Evidence: Per-file `git log --follow` inventory and `git log --all` show no source created or materially changed in the requested 2022-2026 Amalgam period.
+
+- Observation: A clean dependency install resolves `@types/vscode` beyond the syntax understood by the pinned TypeScript 3.6.4 compiler, so `npm run compile` fails before compiling this repository's source.
+  Evidence: `npm install --ignore-scripts --no-package-lock && npm run compile` reports syntax errors in `node_modules/@types/vscode/index.d.ts`; governance validation and its 14 unit tests pass.
+
+## Decision Log
+
+- Decision: Change the repository's current license from MIT to Apache License 2.0 prospectively from the governance commit onward.
+  Rationale: The requested future project license is Apache-2.0, but code and releases previously distributed under MIT remain available under the permissions already granted by MIT.
+  Date: 2026-07-15
+
+- Decision: Use the exact SPDX identifier:
+
+      SPDX-License-Identifier: Apache-2.0
+
+  Rationale: `Apache-2.0` is the canonical SPDX identifier for Apache License 2.0.
+  Date: 2026-07-15
+
+- Decision: Attribute original project creation to Italo Yeltsin (`@ItaloYeltsin`).
+  Rationale: Original creation must remain visible and must not be conflated with present maintenance or current copyright ownership.
+  Date: 2026-07-15
+
+- Decision: Identify Fabio Sobral (`@flsobral`) as the sole current maintainer.
+  Rationale: Current repository responsibility should be unambiguous in the README, authorship documentation, CODEOWNERS, and agent instructions.
+  Date: 2026-07-15
+
+- Decision: Preserve all previously named people in a historical contributors list unless repository evidence shows that a name is erroneous or belongs to an unrelated third party.
+  Rationale: Updating maintenance must not erase legitimate historical contribution.
+  Date: 2026-07-15
+
+- Decision: Remove the obsolete former project contact address from first-party repository content and metadata.
+  Rationale: The email address is obsolete and must no longer be published as a project contact. Historical Git commit metadata must not be rewritten unless separately authorized.
+  Date: 2026-07-15
+
+- Decision: Do not rewrite Git history as part of this plan.
+  Rationale: The requested changes can be represented truthfully in a new governance commit. Existing commit authors, signed commits, tags, and released history must remain intact.
+  Date: 2026-07-15
+
+- Decision: Use period-specific legal headers rather than replacing every historical notice with a single current notice.
+  Rationale: Copyright ownership and licensing must reflect the period and provenance of the work.
+  Date: 2026-07-15
+
+- Decision: Use the following canonical historical classification when supported by repository evidence:
+
+      Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+      SPDX-License-Identifier: MIT
+
+  Rationale: This preserves the requested ownership and MIT licensing for original-period files.
+  Date: 2026-07-15
+
+- Decision: Use the following canonical current-period classification when supported by repository evidence:
+
+      Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda.
+      SPDX-License-Identifier: Apache-2.0
+
+  Rationale: This identifies Amalgam ownership and Apache-2.0 licensing for the requested later period.
+  Date: 2026-07-15
+
+- Decision: Mixed-history files require evidence-based treatment and may include more than one copyright line.
+  Rationale: A file substantially originating in 2020–2021 and later modified in 2022–2026 may legitimately need both ownership statements. Do not erase the earlier owner merely because the current repository license changed.
+  Date: 2026-07-15
+
+- Decision: The first commit contains governance, licensing, attribution, validators, README, agent instructions, planning conventions, and all required header normalization, but no unrelated refactoring.
+  Rationale: This creates a clear legal and operational baseline that can be reviewed independently from implementation changes.
+  Date: 2026-07-15
+
+- Decision: Refactoring begins only after the governance commit passes validation.
+  Rationale: Structural code changes should not obscure or complicate review of relicensing and attribution changes.
+  Date: 2026-07-15
+
+- Decision: Refactoring commits must be grouped by a single coherent purpose and remain buildable whenever practical.
+  Rationale: Logical commits improve review, bisectability, rollback, and future maintenance.
+  Date: 2026-07-15
+
+- Decision: Treat the generated `resources/maven-metadata.xml`, the VS Code quickstart scaffold, binary assets, and legacy modernization ignore file as explicit validator exclusions; validate headers only on executable first-party source/templates and newly added governance tooling.
+  Rationale: These paths either have authoritative generated/scaffold content or cannot carry a syntactically safe file header. The validator still scans all eligible current text for the obsolete contact address.
+  Date: 2026-07-15
+
+- Decision: Defer the TypeScript/@types VS Code compatibility repair to a post-governance build refactoring commit.
+  Rationale: The failure is pre-existing dependency-resolution drift caused by the unpinned development dependency range, not a licensing or attribution change. Keeping it separate preserves the reviewable governance baseline.
+  Date: 2026-07-15
+
+## Outcomes & Retrospective
+
+Complete this section after implementation.
+
+Include:
+
+- repository and branch inspected;
+- whether remote history was preserved unchanged;
+- previous authoritative license files found;
+- exact license transition wording added;
+- number of occurrences of the obsolete former project contact address found, removed, excluded, and why;
+- all people listed as historical contributors before and after the change;
+- files identifying Italo Yeltsin as original creator;
+- files identifying Fabio Sobral as sole maintainer;
+- number of files classified as historical MIT, Amalgam Apache-2.0, mixed history, third-party, generated, or unresolved;
+- number of headers changed in each category;
+- validator commands and CI workflow names;
+- governance commit hash and message;
+- refactoring opportunities considered and rejected;
+- refactoring commits created, with purpose and validation performed for each;
+- public API or compatibility impacts;
+- remaining legal, technical, or documentation follow-ups.
+
+## Context and Orientation
+
+Start by locating repository instructions and understanding the current state:
+
+    pwd
+    git rev-parse --show-toplevel
+    git status --short --branch
+    git remote -v
+    git log --oneline --decorate --graph --all --max-count=80
+    git tag --list --sort=-creatordate | sed -n '1,80p'
+    find .. \( -name AGENTS.md -o -name PLANS.md -o -path '*/.agent/PLANS.md' -o -path '*/.agents/PLANS.md' \) -print
+
+Read all applicable instruction files before editing.
+
+Inventory the repository without traversing generated dependency trees:
+
+    find . -maxdepth 5 -type f \
+      ! -path './.git/*' \
+      ! -path './build/*' \
+      ! -path './dist/*' \
+      ! -path './out/*' \
+      ! -path './target/*' \
+      ! -path './node_modules/*' \
+      | sort | sed -n '1,500p'
+
+Inspect legal, attribution, and contact information:
+
+    git grep -n -I -E \
+      'br\.yeltsin@gmail\.com|Italo Yeltsin|ItaloYeltsin|Fabio Sobral|flsobral|Copyright|SPDX-License-Identifier|SPDX-FileCopyrightText|MIT License|Apache License|maintainer|author|contributor' \
+      -- . \
+      ':(exclude)build/**' \
+      ':(exclude)dist/**' \
+      ':(exclude)out/**' \
+      ':(exclude)target/**' \
+      ':(exclude)node_modules/**' \
+      || true
+
+Inspect authorship evidence from Git without rewriting it:
+
+    git shortlog -sne --all
+    git log --format='%aN <%aE>' --all | sort -fu
+    git log --format='%cN <%cE>' --all | sort -fu
+    git log --follow --format='%h %ad %an <%ae> %s' --date=short -- path/to/important/file
+
+Use `git blame`, `git log --follow`, release tags, imported-source records, and existing notices to classify ambiguous files. Do not infer ownership solely from the most recent editor.
+
+Inspect build and test entry points:
+
+    find . -maxdepth 4 -type f \( \
+      -name 'build.gradle' -o \
+      -name 'build.gradle.kts' -o \
+      -name 'settings.gradle' -o \
+      -name 'settings.gradle.kts' -o \
+      -name 'gradlew' -o \
+      -name 'pom.xml' -o \
+      -name 'CMakeLists.txt' -o \
+      -name 'Makefile' -o \
+      -name 'package.json' -o \
+      -name 'Cargo.toml' \
+    \) -print | sort
+
+## License Transition Rules
+
+### Repository license files
+
+Replace the current top-level MIT license file with the complete Apache License 2.0 text in `LICENSE` or the repository's established license filename.
+
+Add `NOTICE` when appropriate. At minimum it should identify:
+
+- the current project name;
+- original project creation by Italo Yeltsin (`@ItaloYeltsin`);
+- current maintenance by Fabio Sobral (`@flsobral`);
+- the historical MIT licensing period where applicable;
+- Amalgam Solucoes em TI Ltda. as the 2022–2026 copyright holder where applicable;
+- preservation of third-party notices.
+
+Do not place terms in `NOTICE` that contradict Apache-2.0 or attempt to revoke historical MIT permissions.
+
+Document the transition in README or a dedicated licensing section with wording equivalent to:
+
+    Versions and source distributions released before this license transition may
+    remain available under the MIT License terms that accompanied them. From this
+    governance change onward, project work controlled by the current copyright
+    holder is licensed under the Apache License, Version 2.0, unless a file states
+    otherwise.
+
+Adapt wording to verified repository history and release facts.
+
+### Canonical file-header categories
+
+Prefer SPDX metadata, but retain requested human-readable copyright lines when they are part of the project's established header format.
+
+#### Historical TotalCross files
+
+For a file whose controlled first-party content belongs only to the 2020–2021 period:
+
+    Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+    SPDX-License-Identifier: MIT
+
+Do not change it to Apache-2.0 merely because the repository's current license changed.
+
+#### Amalgam files
+
+For a file created entirely in the 2022–2026 Amalgam period, or for a new file added by this work:
+
+    Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda.
+    SPDX-License-Identifier: Apache-2.0
+
+For a file first created in a later year, do not invent 2022 unless the project explicitly requires a common range. Record and follow the repository's legal convention.
+
+#### Mixed-history files
+
+For files containing material from both periods, use both copyright statements when supported:
+
+    Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+    Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda.
+    SPDX-License-Identifier: Apache-2.0
+
+Before applying Apache-2.0 to the combined current file, confirm that the relevant rights holder is authorized to relicense the inherited MIT code and that no contributor-specific restriction prevents it. MIT permits redistribution under additional terms provided its notice is preserved, but the original MIT notice and disclaimer must remain available where legally required. Record the chosen representation in `Decision Log`.
+
+If the safest accurate treatment is dual licensing or preserving an MIT identifier for a particular file, do not force Apache-2.0. Record the exception.
+
+#### Third-party and generated files
+
+Do not replace, remove, or normalize third-party notices. Do not manually edit generated files when the generator can be changed instead.
+
+### Comment syntax
+
+Preserve shebangs, XML declarations, encoding declarations, and generated markers.
+
+C-style example:
+
+    /*
+     * Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda.
+     * SPDX-License-Identifier: Apache-2.0
+     */
+
+Hash-comment example:
+
+    # Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda.
+    # SPDX-License-Identifier: Apache-2.0
+
+XML example:
+
+    <!--
+      Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda.
+      SPDX-License-Identifier: Apache-2.0
+    -->
+
+## Attribution and Governance Files
+
+### `README.md`
+
+Update the README to include concise, visible sections covering:
+
+- project purpose and supported use;
+- license and transition note;
+- original creator: Italo Yeltsin (`@ItaloYeltsin`);
+- sole maintainer: Fabio Sobral (`@flsobral`);
+- link to `AUTHORS.md` or contributors documentation;
+- local build, test, and validation commands;
+- contribution entry point.
+
+Remove the obsolete former project contact address. Do not replace it with another email unless explicitly requested.
+
+### `AUTHORS.md`
+
+Create or update with a structure similar to:
+
+    # Authors and contributors
+
+    ## Original creator
+
+    Italo Yeltsin ([@ItaloYeltsin](https://github.com/ItaloYeltsin))
+
+    ## Current maintainer
+
+    Fabio Sobral ([@flsobral](https://github.com/flsobral))
+
+    Fabio Sobral is the sole current maintainer.
+
+    ## Historical contributors
+
+    - <preserved names discovered in the repository>
+
+    Additional contributors are recorded in Git history.
+
+    ## Copyright history
+
+    - 2020-2021: TotalCross Global Mobile Platform Ltda., for applicable original work.
+    - 2022-2026: Amalgam Solucoes em TI Ltda., for applicable later work.
+
+Do not invent contributor names. Deduplicate spelling variants only after checking Git history and repository evidence.
+
+### `.github/CODEOWNERS`
+
+Set Fabio Sobral as the default current code owner:
+
+    * @flsobral
+
+Preserve valid path-specific rules if they still reflect active ownership. Remove obsolete rules that designate former maintainers only after recording the change.
+
+### `CONTRIBUTING.md`
+
+Document:
+
+- the current Apache-2.0 contribution license expectation;
+- the historical-license exception policy;
+- required headers for new first-party files;
+- prohibition against changing third-party notices;
+- the local validation command;
+- build and test commands;
+- commit expectations for coherent changes;
+- how to update generated files and their generators;
+- that Fabio Sobral is the sole current maintainer and reviewer of record.
+
+Do not assert copyright assignment or a contributor license agreement unless one actually exists.
+
+### `AGENTS.md`
+
+Create a repository-root `AGENTS.md` that tells coding agents to:
+
+- read `AGENTS.md` and `.agent/PLANS.md` before modifying files;
+- inspect Git status and repository instructions first;
+- preserve historical copyright and third-party notices;
+- never reintroduce the obsolete former project contact address;
+- use Apache-2.0 headers for new first-party files unless a documented exception applies;
+- avoid broad formatting or refactoring in governance-only changes;
+- keep commits logical, buildable, and narrowly described;
+- prefer focused validation before expensive full builds;
+- keep build output concise and save verbose logs to files when useful;
+- update an active ExecPlan while performing long or multi-step work;
+- avoid rewriting history, force-pushing, deleting tags, or changing release artifacts without explicit authorization;
+- report unresolved licensing or provenance ambiguity instead of guessing.
+
+Include repository-specific build, test, formatting, and validation commands discovered during inspection.
+
+### `.agent/PLANS.md`
+
+Create `.agent/PLANS.md` defining the required structure and maintenance rules for Codex ExecPlans in this repository.
+
+It must require at least:
+
+- `Purpose / Big Picture`;
+- `Progress` with timestamped checkboxes when useful;
+- `Surprises & Discoveries`;
+- `Decision Log`;
+- `Outcomes & Retrospective`;
+- concrete file paths and commands;
+- observable acceptance criteria;
+- continuous updates during execution;
+- explicit documentation of deviations and unresolved risks.
+
+Use `.agent/PLANS.md` exactly as requested. Do not silently substitute `.agents/PLANS.md`; if an existing convention uses the plural directory, document the conflict and either migrate references consistently or preserve a compatibility pointer.
+
+## Validation Tooling
+
+Implement a deterministic, dependency-light validator in the repository's existing scripting language where practical.
+
+It must:
+
+1. enumerate tracked candidate files using Git, preferably `git ls-files -z`;
+2. classify paths through explicit inclusion and exclusion rules;
+3. validate expected copyright and SPDX combinations;
+4. reject `SPDX-License-Identifier: MIT` for new Amalgam-era first-party files unless explicitly excepted;
+5. reject removal of required historical MIT notices from classified historical files;
+6. reject the obsolete former project contact address in first-party tracked content;
+7. verify README, AUTHORS, CODEOWNERS, AGENTS, and `.agent/PLANS.md` contain required current attribution;
+8. ensure Italo Yeltsin is identified as original creator, not current maintainer;
+9. ensure Fabio Sobral is identified as sole current maintainer;
+10. preserve an explicit allowlist for third-party, generated, fixtures, and unavoidable historical artifacts;
+11. print concise, sorted, path-based diagnostics;
+12. exit nonzero on failure;
+13. avoid modifying files;
+14. support paths containing spaces and non-ASCII characters.
+
+Suitable commands might be:
+
+    python3 tools/check-repository-governance.py
+    python3 -m unittest tests.test_repository_governance
+
+Use actual repository conventions and document the final commands in README, CONTRIBUTING, AGENTS, and CI.
+
+At minimum test:
+
+- valid historical MIT header;
+- valid Amalgam Apache-2.0 header;
+- valid mixed-history header;
+- missing historical notice;
+- incorrect owner/year combination;
+- obsolete email detection;
+- third-party exclusion;
+- generated-file exclusion;
+- Italo incorrectly marked as current maintainer;
+- Fabio missing as sole maintainer;
+- deterministic diagnostics;
+- path containing spaces;
+- shebang and XML declaration placement.
+
+## Required First Commit: Governance and License Transition
+
+The first commit must include all related governance changes and header normalization together, and must exclude unrelated implementation refactoring.
+
+Expected content includes, as applicable:
+
+    LICENSE
+    NOTICE
+    README.md
+    AUTHORS.md
+    CONTRIBUTING.md
+    AGENTS.md
+    .agent/PLANS.md
+    .github/CODEOWNERS
+    .github/workflows/<governance-validation>.yml
+    tools/<validator>
+    tests/<validator-tests-or-fixtures>
+    all applicable first-party files whose headers are normalized
+    project metadata files containing obsolete contact, authorship, maintainer, or license information
+
+Before staging, produce explicit inventories:
+
+    git grep -n -I 'br\.yeltsin@gmail\.com' -- . || true
+    git grep -n -I -E 'SPDX-License-Identifier: MIT|SPDX-License-Identifier: Apache-2.0' -- . || true
+    git status --short
+
+Stage deliberately. Review:
+
+    git diff --check
+    git diff --cached --stat
+    git diff --cached -- LICENSE NOTICE README.md AUTHORS.md CONTRIBUTING.md AGENTS.md .agent/PLANS.md .github tools tests
+    git diff --cached
+
+Run validators and focused build/tests before committing.
+
+Recommended commit message:
+
+    chore(governance): migrate project licensing to Apache-2.0
+
+The commit body should explain:
+
+- prospective MIT to Apache-2.0 transition;
+- preserved historical MIT attribution;
+- original creator and current maintainer roles;
+- obsolete email removal;
+- addition of validators, CI, AGENTS, and planning rules;
+- project-wide header normalization.
+
+Do not split this governance baseline into several commits unless a repository instruction explicitly requires it. Do not include code cleanup, renaming, package moves, formatting-only sweeps, behavior changes, or dependency upgrades unrelated to making the governance baseline valid.
+
+## Post-Governance Code Review
+
+After the first commit is complete, start from a clean working tree and inspect the code systematically.
+
+Review:
+
+- module and package boundaries;
+- source and test directory organization;
+- public API versus implementation details;
+- duplicated or dead code;
+- naming consistency;
+- dependency direction and cycles;
+- platform-specific code placement;
+- generated code and generators;
+- build scripts and dependency declarations;
+- error handling and resource lifecycle;
+- test coverage and testability;
+- unnecessary compatibility layers;
+- documentation that no longer matches behavior;
+- large files or classes with multiple responsibilities;
+- opportunities to separate reusable core logic from adapters or platform integrations.
+
+Use static tools already present in the repository. Do not add a major formatter, linter, dependency, or build system merely to perform cleanup unless the benefit is documented and separately reviewable.
+
+Before structural changes, add characterization tests when behavior is not adequately protected.
+
+## Logical Refactoring Commit Strategy
+
+Each refactoring commit must have one primary purpose. Examples, used only when supported by the actual project:
+
+1. `test(core): add characterization coverage for current behavior`
+2. `refactor(build): normalize source sets and generated outputs`
+3. `refactor(core): separate parsing from execution`
+4. `refactor(platform): isolate platform-specific adapters`
+5. `refactor(api): clarify internal and public package boundaries`
+6. `refactor(resources): centralize resource loading and cleanup`
+7. `docs(architecture): document the reorganized module structure`
+
+For every proposed group:
+
+- record the problem and evidence in `Decision Log`;
+- list exact files and expected behavioral impact;
+- identify compatibility risks;
+- run focused tests before and after;
+- avoid mixing formatting-only changes with semantic changes;
+- avoid moving and rewriting a file in the same commit when that would make review unnecessarily difficult;
+- update imports, build configuration, tests, and documentation in the same commit when required to keep the tree buildable;
+- use `git diff --check` and inspect the complete staged diff;
+- include the reason for the change in the commit body, not only a description of file movements.
+
+If no meaningful refactoring is justified, do not manufacture changes. Record that the review found no safe, valuable reorganization within scope.
+
+## Validation and Acceptance
+
+The plan is complete only when all applicable conditions are observable:
+
+- the current top-level license is Apache License 2.0;
+- historical MIT permissions and notices are not falsely revoked or erased;
+- the obsolete former project contact address is absent from first-party current repository content, subject to documented exclusions;
+- Italo Yeltsin is clearly identified as original creator;
+- Fabio Sobral is clearly identified as the sole current maintainer;
+- all previously credited legitimate people remain in a historical contributors list;
+- `.github/CODEOWNERS` identifies `@flsobral` as the default current owner;
+- `AGENTS.md` exists and contains repository-specific operational rules;
+- `.agent/PLANS.md` exists and defines ExecPlan requirements;
+- applicable source headers match their verified historical category;
+- third-party and generated notices remain intact;
+- validators pass locally and in CI;
+- README and CONTRIBUTING document the exact validation command;
+- the governance commit contains no unrelated refactoring;
+- each later refactoring commit is coherent, justified, and validated;
+- the final supported build and test suite passes, or every pre-existing failure is clearly distinguished from regressions introduced by this work;
+- the working tree is clean;
+- the final commit history is understandable without external explanation.
+
+## Final Review Checklist
+
+- [ ] Existing repository instructions were read and followed.
+- [ ] No Git history was rewritten.
+- [ ] Apache-2.0 license text is complete and authoritative.
+- [ ] Historical MIT licensing is accurately documented.
+- [ ] The obsolete former project contact address has been removed or each retained occurrence is justified.
+- [ ] Italo Yeltsin is credited as original creator.
+- [ ] Fabio Sobral is the sole current maintainer.
+- [ ] Historical contributors are preserved.
+- [ ] TotalCross 2020–2021 headers retain MIT where applicable.
+- [ ] Amalgam 2022–2026 headers use Apache-2.0 where applicable.
+- [ ] Mixed-history files were reviewed individually.
+- [ ] Third-party notices were not overwritten.
+- [ ] Generated files were updated through generators where possible.
+- [ ] `AGENTS.md` exists and is repository-specific.
+- [ ] `.agent/PLANS.md` exists and is referenced consistently.
+- [ ] Validator tests pass.
+- [ ] CI invokes the same validator command documented locally.
+- [ ] The first commit contains governance only, including required header changes.
+- [ ] Refactoring began only after the governance commit.
+- [ ] Each refactoring commit has one coherent purpose.
+- [ ] Public API and compatibility impacts are documented.
+- [ ] Full final build/tests pass or known failures are recorded.
+- [ ] `git diff --check` passes.
+- [ ] Working tree is clean.
+- [ ] `Outcomes & Retrospective` is complete.

--- a/.agent/exec-plan-mit-to-apache-governance-refactor.md
+++ b/.agent/exec-plan-mit-to-apache-governance-refactor.md
@@ -60,8 +60,8 @@ The plan must not claim that code originally distributed under MIT retroactively
 - [x] (2026-07-15) Ran the full supported `npm test` suite after recompilation; the deprecated `vscode-test` wrapper downloaded VS Code 1.129.0 but failed to launch it on macOS with unsupported Electron option errors.
 - [x] (2026-07-15) Recorded a second build/test tooling refactoring group before changing it: replace the deprecated wrapper with its maintained `@vscode/test-electron` successor.
 - [x] (2026-07-15) Implemented and validated the test tooling refactoring: `npm test` launches VS Code 1.129.0 and reports two passing extension tests after clearing the inherited Electron Node-mode marker.
-- [ ] Review the final commit sequence for accidental mixing of governance and implementation work.
-- [ ] Complete `Outcomes & Retrospective` with counts, commands, commit hashes, exceptions, and follow-up items.
+- [x] (2026-07-15) Reviewed the final sequence: `ca549be` is governance-only; `b7072bd` isolates dependency compatibility; `d8dc0e6` isolates integration-test tooling.
+- [x] (2026-07-15) Completed `Outcomes & Retrospective` and the evidence-based `Editorial Report` below.
 
 ## Surprises & Discoveries
 
@@ -196,26 +196,166 @@ Do not silently resolve legal, attribution, or historical ambiguity. Record the 
 
 ## Outcomes & Retrospective
 
-Complete this section after implementation.
+The `master` branch of `TotalCross/totalcross-vscode-plugin` was inspected at
+`6948213`; the remote history, tags, and old commit identities were preserved
+unchanged. The prior top-level `LICENSE` was MIT with a 2019 TotalCross notice.
+It is now Apache License 2.0 for the current repository baseline. `README.md`
+states that distributions released before this governance change may remain
+available under their accompanying MIT terms and that current controlled work
+is Apache-2.0 unless a file states otherwise.
 
-Include:
+One current-content obsolete-contact occurrence was found in the old README
+and removed. No occurrence remains in current tracked content. Git commit
+metadata was intentionally not rewritten. `AUTHORS.md` preserves the original
+creator Italo Yeltsin, the sole current maintainer Fabio Sobral, and historical
+contributors Allan C, lucasgalvanini, @nmarquesin, and Ricardo Braga based on
+the former README or Git history.
 
-- repository and branch inspected;
-- whether remote history was preserved unchanged;
-- previous authoritative license files found;
-- exact license transition wording added;
-- number of occurrences of the obsolete former project contact address found, removed, excluded, and why;
-- all people listed as historical contributors before and after the change;
-- files identifying Italo Yeltsin as original creator;
-- files identifying Fabio Sobral as sole maintainer;
-- number of files classified as historical MIT, Amalgam Apache-2.0, mixed history, third-party, generated, or unresolved;
-- number of headers changed in each category;
-- validator commands and CI workflow names;
-- governance commit hash and message;
-- refactoring opportunities considered and rejected;
-- refactoring commits created, with purpose and validation performed for each;
-- public API or compatibility impacts;
-- remaining legal, technical, or documentation follow-ups.
+`README.md`, `AUTHORS.md`, `NOTICE`, `CONTRIBUTING.md`, `AGENTS.md`, and
+`.github/CODEOWNERS` identify the roles and transition. Twenty-one historical
+first-party source/template files carry TotalCross MIT headers. Nine new
+governance/tooling documents or scripts carry Amalgam Apache-2.0 headers.
+No mixed-history production file was found before refactoring; the later narrow
+test-runner edit retains the existing historical MIT header as documented in
+the decision log. `resources/maven-metadata.xml` is treated as generated;
+the VS Code quickstart scaffold, binary assets, and a legacy modernization
+ignore file are explicit exclusions. No unresolved ownership ambiguity remains
+within the files changed by this work, but the prospective relicensing authority
+is represented by the requested governance decision rather than independent
+external legal verification.
+
+The local governance checks are `python3 tools/check-repository-governance.py`
+and `python3 -m unittest tests.test_repository_governance`; the GitHub Actions
+workflow is `.github/workflows/governance-validation.yml`. The validator passed
+and its 14 unit tests passed. `npm run compile` passed after the build
+dependency correction. `npm test` passed with two extension tests using VS Code
+1.129.0 and exited with code 0.
+
+The governance commit is `ca549be4b8428ae260df05ec9529578e687fcaac`
+(`chore(governance): migrate project licensing to Apache-2.0`). The later
+`b7072bd` pins `@types/vscode` to 1.40.0 so TypeScript can parse the VS Code
+API types. `d8dc0e6` replaces the deprecated test wrapper and prevents the
+host's Electron Node-mode environment marker from breaking integration tests.
+No public extension command, runtime dependency, API, resource path, or
+platform behavior changed. Broader source reorganization and security-related
+cleanup were considered but rejected because the small codebase has sparse
+behavioral coverage and those changes were not necessary to make the baseline
+valid and buildable. npm reports 17 dependency vulnerabilities after the final
+install; dependency security modernization is a separate follow-up.
+
+## Editorial Report
+
+### Editorial Summary
+
+This work establishes a truthful legal and maintenance baseline for the
+TotalCross VS Code extension. Users and contributors can now see the current
+Apache-2.0 license, the continuing MIT status of historical TotalCross source,
+the original creator, and the sole current maintainer. A local validator and
+matching CI workflow make those rules repeatable rather than relying on manual
+review alone.
+
+The execution also restored a usable development verification path: compilation
+uses a compatible VS Code type definition package, and the extension tests run
+successfully from a VS Code-hosted development environment.
+
+### Original Plan versus Actual Outcome
+
+The governance transition, attribution documentation, header normalization,
+validator, tests, CI, and logical baseline commit were delivered as planned.
+The code review found no safe structural reorganization worth manufacturing.
+Instead, it found two concrete build/test compatibility regressions caused by
+dependency and host-environment drift; those were resolved in two separately
+reviewable refactoring commits.
+
+### What Changed
+
+`LICENSE`, `NOTICE`, `README.md`, `AUTHORS.md`, `CONTRIBUTING.md`, `AGENTS.md`,
+and `.github/CODEOWNERS` define the project license, ownership history, and
+maintenance roles. `tools/check-repository-governance.py` validates headers,
+attribution, and obsolete contact information, while
+`tests/test_repository_governance.py` supplies its focused tests and
+`.github/workflows/governance-validation.yml` runs them in CI. Historical
+headers were added to `src/`, first-party `resources/`, and `test.sh`.
+
+`package.json` pins the VS Code API type package and adopts
+`@vscode/test-electron`. `src/test/runTest.ts` clears an inherited process
+variable before launching VS Code so the integration application is not forced
+into Node mode.
+
+### Decisions and Trade-offs
+
+The repository transition is prospective: the current root license changes,
+but historical source retains MIT headers. This avoids claiming that prior
+releases were retroactively relicensed. Header enforcement deliberately uses a
+small Python script and explicit path categories, trading automatic historical
+inference for readable, auditable rules. The maintained test package is kept on
+its 2.5 major line because its 3.0 declarations are incompatible with the
+project's TypeScript compiler.
+
+### Unexpected Problems and Discoveries
+
+An unpinned VS Code type dependency resolved to 1.125.0, which TypeScript 3.9
+could not parse. The deprecated test wrapper then failed to launch a current
+macOS VS Code, and the maintained replacement initially inherited
+`ELECTRON_RUN_AS_NODE=1` from the host process. Removing that variable at the
+test launcher boundary produced a successful test run.
+
+### Validation and Measurable Results
+
+Observed successful commands were:
+
+    python3 tools/check-repository-governance.py
+    python3 -m unittest tests.test_repository_governance
+    npm run compile
+    npm test
+
+The governance validator passed; 14 governance tests passed; compilation
+passed; and the VS Code integration run reported two passing tests and exit
+code 0. The final search found zero current-content occurrences of the obsolete
+contact address. No performance or artifact-size measurement was taken.
+
+### Useful Evidence and Examples
+
+The three commits `ca549be`, `b7072bd`, and `d8dc0e6` separate the governance,
+build, and test work. `tools/check-repository-governance.py` and
+`tests/test_repository_governance.py` provide reproducible policy evidence.
+The final `npm test` transcript records the two passing extension tests.
+
+### Limitations, Remaining Work, and Open Questions
+
+The authority for prospective relicensing follows the requested governance
+decision and was not independently verified with external legal records.
+The repository has no lockfile, so transitive dependencies can still drift.
+npm reports 17 vulnerabilities in the installed dependency tree; resolving
+them safely requires a dedicated dependency upgrade and compatibility review.
+Existing extension tests remain minimal and do not characterize deployment,
+packaging, or project-creation behavior.
+
+### Possible Article Angles
+
+- For maintainers of older extensions: "Separating a license transition from
+  compatibility fixes" explains how small, logical commits preserve legal and
+  technical reviewability.
+- For extension-tooling maintainers: "Why VS Code integration tests started
+  Node instead of Electron" shows how inherited host environment variables can
+  change a child process's execution mode.
+- For open-source maintainers: "Turning repository governance into a test"
+  shows a dependency-light approach to validating headers and attribution.
+
+### Suggested Narrative
+
+Start with a legacy extension whose legal metadata and tooling have drifted.
+Explain the constraint that historical MIT work must remain truthful. Introduce
+the governance baseline and its validator, then show the unexpected type and
+Electron-launch failures discovered only through real verification. Conclude
+with the isolated fixes, passing checks, and the remaining dependency-security
+work.
+
+### Claims Requiring Human Review
+
+The stated ownership periods, prospective relicensing authority, historical
+contributor identities, and sole-maintainer status are externally visible and
+should receive legal and maintainer review before publication or release.
 
 ## Context and Orientation
 
@@ -643,28 +783,32 @@ The plan is complete only when all applicable conditions are observable:
 
 ## Final Review Checklist
 
-- [ ] Existing repository instructions were read and followed.
-- [ ] No Git history was rewritten.
-- [ ] Apache-2.0 license text is complete and authoritative.
-- [ ] Historical MIT licensing is accurately documented.
-- [ ] The obsolete former project contact address has been removed or each retained occurrence is justified.
-- [ ] Italo Yeltsin is credited as original creator.
-- [ ] Fabio Sobral is the sole current maintainer.
-- [ ] Historical contributors are preserved.
-- [ ] TotalCross 2020–2021 headers retain MIT where applicable.
-- [ ] Amalgam 2022–2026 headers use Apache-2.0 where applicable.
-- [ ] Mixed-history files were reviewed individually.
-- [ ] Third-party notices were not overwritten.
-- [ ] Generated files were updated through generators where possible.
-- [ ] `AGENTS.md` exists and is repository-specific.
-- [ ] `.agent/PLANS.md` exists and is referenced consistently.
-- [ ] Validator tests pass.
-- [ ] CI invokes the same validator command documented locally.
-- [ ] The first commit contains governance only, including required header changes.
-- [ ] Refactoring began only after the governance commit.
-- [ ] Each refactoring commit has one coherent purpose.
-- [ ] Public API and compatibility impacts are documented.
-- [ ] Full final build/tests pass or known failures are recorded.
-- [ ] `git diff --check` passes.
-- [ ] Working tree is clean.
-- [ ] `Outcomes & Retrospective` is complete.
+- [x] Existing repository instructions were read and followed.
+- [x] No Git history was rewritten.
+- [x] Apache-2.0 license text is complete and authoritative.
+- [x] Historical MIT licensing is accurately documented.
+- [x] The obsolete former project contact address has been removed; no current-content occurrence remains.
+- [x] Italo Yeltsin is credited as original creator.
+- [x] Fabio Sobral is the sole current maintainer.
+- [x] Historical contributors are preserved.
+- [x] TotalCross 2020–2021 headers retain MIT where applicable.
+- [x] Amalgam 2022–2026 headers use Apache-2.0 where applicable.
+- [x] Mixed-history files were reviewed; no production mixed file requires a combined header.
+- [x] Third-party notices were not overwritten.
+- [x] Generated files were left intact; no generator update was necessary.
+- [x] `AGENTS.md` exists and is repository-specific.
+- [x] `.agent/PLANS.md` exists and is referenced consistently.
+- [x] Validator tests pass.
+- [x] CI invokes the same validator command documented locally.
+- [x] The first commit contains governance only, including required header changes.
+- [x] Refactoring began only after the governance commit.
+- [x] Each refactoring commit has one coherent purpose.
+- [x] Public API and compatibility impacts are documented.
+- [x] Full final build/tests pass.
+- [x] `git diff --check` passes.
+- [x] Working tree is clean after this plan-record commit.
+- [x] `Outcomes & Retrospective` is complete.
+
+Revision note (2026-07-15): recorded the completed governance transition,
+dependency and test-runner compatibility refactorings, observed validation
+results, remaining dependency-security work, and the final Editorial Report.

--- a/.agent/exec-plan-mit-to-apache-governance-refactor.md
+++ b/.agent/exec-plan-mit-to-apache-governance-refactor.md
@@ -62,6 +62,10 @@ The plan must not claim that code originally distributed under MIT retroactively
 - [x] (2026-07-15) Implemented and validated the test tooling refactoring: `npm test` launches VS Code 1.129.0 and reports two passing extension tests after clearing the inherited Electron Node-mode marker.
 - [x] (2026-07-15) Reviewed the final sequence: `ca549be` is governance-only; `b7072bd` isolates dependency compatibility; `d8dc0e6` isolates integration-test tooling.
 - [x] (2026-07-15) Completed `Outcomes & Retrospective` and the evidence-based `Editorial Report` below.
+- [x] (2026-07-15) Reopened the ExecPlan at the maintainer's request to correct dependency vulnerabilities; confirmed that the repository lacks a lockfile and therefore `npm audit` cannot produce a trustworthy dependency graph.
+- [x] (2026-07-15) Generated `package-lock.json` and audited the reproducible graph: 17 findings (2 critical, 4 high, 9 moderate, 2 low) came from request-related runtime dependencies, `node-ssh`, Mocha, TSLint, and their transitives.
+- [x] (2026-07-15) Applied the dependency security corrections and validated an installation from the lockfile: `npm audit` now reports 0 vulnerabilities; compilation, governance validation (15 tests), and the three-test VS Code integration suite pass.
+- [ ] Commit the security correction and reconcile its hash and evidence into the final outcome sections.
 
 ## Surprises & Discoveries
 
@@ -96,6 +100,15 @@ Do not silently resolve legal, attribution, or historical ambiguity. Record the 
 
 - Observation: The Electron launch errors are caused by the inherited `ELECTRON_RUN_AS_NODE=1` environment variable, not by the downloaded VS Code application.
   Evidence: The active extension-host environment contains that variable; Electron reports Node-style `bad option` errors for the VS Code launch arguments. Removing it before `runTests` lets Electron launch as the VS Code application.
+
+- Observation: `npm audit` cannot run without a lockfile, so the prior vulnerability count was tied to a transient local install and could not be reproduced from version-controlled dependency metadata.
+  Evidence: `npm audit --json` exits with `ENOLOCK` and requests `npm i --package-lock-only`; no `package-lock.json` is tracked.
+
+- Observation: Updating Mocha to its audit-safe major removes the `useColors` instance method used by the legacy test runner.
+  Evidence: Compilation after the dependency update reports `Property 'useColors' does not exist on type 'Mocha'` in `src/test/suite/index.ts`; the equivalent supported constructor option is `color: true`.
+
+- Observation: The lockfile-backed audit initially found 17 vulnerabilities, including two critical findings in the abandoned request stack; after the replacements, upgrades, and overrides it found zero.
+  Evidence: `npm install --ignore-scripts && npm audit` reported 17 findings before the changes, while `npm ci --ignore-scripts && npm run audit` completed with `found 0 vulnerabilities` afterward.
 
 ## Decision Log
 
@@ -192,6 +205,26 @@ Do not silently resolve legal, attribution, or historical ambiguity. Record the 
 
 - Decision: Keep the historical MIT header on `src/test/runTest.ts` after the narrow test-runner changes.
   Rationale: The file remains predominately 2019 TotalCross work; the import and environment sanitization are a minimal compatibility adjustment. The validator records it as historical work and preserves the existing MIT notice rather than asserting an unsupported whole-file relicensing.
+  Date: 2026-07-15
+
+- Decision: Add and maintain `package-lock.json` as part of the vulnerability correction work.
+  Rationale: A lockfile makes the dependency graph reproducible, lets `npm audit` analyze the exact resolved packages, and prevents security results from silently changing between installs. It will be generated with npm and reviewed as dependency metadata, not hand-edited.
+  Date: 2026-07-15
+
+- Decision: Remove the abandoned `request` stack and `totalcross-core-dev` rather than accepting an unsafe forced audit fix.
+  Rationale: `request`, `request-promise`, and `totalcross-core-dev` keep the two critical advisories reachable and have no safe compatible audit fix. The extension uses only the core package's Maven metadata helpers, so those helpers will be implemented locally with Node's `https` module and the already-present `xml-js` parser. The unused direct request imports will be removed.
+  Date: 2026-07-15
+
+- Decision: Replace `pom-parser` with the existing `xml-js` dependency, update `node-ssh` and Mocha to their audit-safe majors, and add focused Maven metadata parsing coverage.
+  Rationale: `pom-parser` has no upstream audit fix and only supplies a project name from POM XML. `node-ssh` and Mocha have published upgrade paths that remove their vulnerable transitive dependencies. Parsing tests protect the new local metadata helper without depending on a network service.
+  Date: 2026-07-15
+
+- Decision: Remove the unused, deprecated TSLint dependency and use npm overrides for Mocha's vulnerable transitive packages.
+  Rationale: No npm script invokes TSLint, and keeping an unused deprecated tool preserves vulnerable `diff` and `js-yaml` packages. Mocha's published range still resolves vulnerable versions of `diff` and `serialize-javascript`; exact npm overrides select their patched releases and will be proven by the extension test suite.
+  Date: 2026-07-15
+
+- Decision: Retain the historical MIT headers on modified legacy source files and use Apache-2.0 headers only for the new Maven metadata module and its test.
+  Rationale: `src/creator.ts`, `src/deployer.ts`, `src/config-checker.ts`, `src/util.ts`, and the existing test runner remain predominately historical TotalCross work. The security edits are narrow replacements or removals within those files. `src/maven-metadata.ts` and `src/test/suite/maven-metadata.test.ts` are newly authored current-period work and are classified and validated as Amalgam Apache-2.0.
   Date: 2026-07-15
 
 ## Outcomes & Retrospective

--- a/.agent/exec-plan-mit-to-apache-governance-refactor.md
+++ b/.agent/exec-plan-mit-to-apache-governance-refactor.md
@@ -57,7 +57,9 @@ The plan must not claim that code originally distributed under MIT retroactively
 - [x] (2026-07-15) Recorded the build dependency refactoring group before changing it.
 - [x] (2026-07-15) Implemented the build dependency refactoring by pinning `@types/vscode` to 1.40.0; `npm run compile`, governance validation, and 14 governance unit tests pass.
 - [x] (2026-07-15) Ran focused validation for the build dependency refactoring; no source or public API behavior changed.
-- [x] (2026-07-15) Ran the full supported `npm test` suite successfully after recompilation; it downloaded and launched VS Code 1.129.0 through `vscode-test`.
+- [x] (2026-07-15) Ran the full supported `npm test` suite after recompilation; the deprecated `vscode-test` wrapper downloaded VS Code 1.129.0 but failed to launch it on macOS with unsupported Electron option errors.
+- [x] (2026-07-15) Recorded a second build/test tooling refactoring group before changing it: replace the deprecated wrapper with its maintained `@vscode/test-electron` successor.
+- [x] (2026-07-15) Implemented and validated the test tooling refactoring: `npm test` launches VS Code 1.129.0 and reports two passing extension tests after clearing the inherited Electron Node-mode marker.
 - [ ] Review the final commit sequence for accidental mixing of governance and implementation work.
 - [ ] Complete `Outcomes & Retrospective` with counts, commands, commit hashes, exceptions, and follow-up items.
 
@@ -85,6 +87,15 @@ Do not silently resolve legal, attribution, or historical ambiguity. Record the 
 
 - Observation: A clean dependency install resolves `@types/vscode` beyond the syntax understood by the pinned TypeScript 3.6.4 compiler, so `npm run compile` fails before compiling this repository's source.
   Evidence: `npm install --ignore-scripts --no-package-lock && npm run compile` reports syntax errors in `node_modules/@types/vscode/index.d.ts`; governance validation and its 14 unit tests pass.
+
+- Observation: The deprecated `vscode-test` package cannot launch the latest downloaded VS Code on macOS; the process reports `bad option: --no-sandbox` and exits with code 9.
+  Evidence: The second final `npm test` attempt reused VS Code 1.129.0 and failed from `src/test/runTest.ts` before the extension test suite could run.
+
+- Observation: `@vscode/test-electron` 3.0.0 supports the active Node.js runtime but exposes declaration syntax incompatible with the project's TypeScript 3.9 compiler.
+  Evidence: A clean install followed by compilation reports `Type 'Buffer' is not generic` in `@vscode/test-electron/out/util.d.ts`.
+
+- Observation: The Electron launch errors are caused by the inherited `ELECTRON_RUN_AS_NODE=1` environment variable, not by the downloaded VS Code application.
+  Evidence: The active extension-host environment contains that variable; Electron reports Node-style `bad option` errors for the VS Code launch arguments. Removing it before `runTests` lets Electron launch as the VS Code application.
 
 ## Decision Log
 
@@ -165,6 +176,22 @@ Do not silently resolve legal, attribution, or historical ambiguity. Record the 
 
 - Decision: Pin `@types/vscode` to `1.40.0` in a standalone `refactor(build)` commit, while retaining the established TypeScript `^3.6.4` range.
   Rationale: The extension declares VS Code engine `^1.40.0`; the old caret on its corresponding type definitions resolved to 1.125.0, whose declarations cannot be parsed by the resolved TypeScript 3.9.10 compiler. The exact historical API type package restores a reproducible compatible bound without changing runtime dependencies or extension behavior.
+  Date: 2026-07-15
+
+- Decision: Replace deprecated `vscode-test` with `@vscode/test-electron` in a separate `refactor(test)` commit.
+  Rationale: npm marks `vscode-test` as renamed, and its current resolved wrapper cannot launch VS Code 1.129.0 in this macOS environment. The maintained successor provides the same `runTests` API used by `src/test/runTest.ts` and supports the active Node.js runtime.
+  Date: 2026-07-15
+
+- Decision: Use the maintained `@vscode/test-electron` 2.5 release line rather than 3.0.0.
+  Rationale: Version 3.0.0 requires a newer TypeScript declaration environment than this extension's compiler; the current 2.5 line supports Node.js 16 or later while avoiding that compiler incompatibility. The range keeps compatible maintenance updates within the selected major version.
+  Date: 2026-07-15
+
+- Decision: Delete `ELECTRON_RUN_AS_NODE` in `src/test/runTest.ts` before launching integration tests.
+  Rationale: This environment marker is correct for the host process that starts Codex but incorrect for the child VS Code application. The test script is the narrowest boundary at which to prevent the inheritance without changing user runtime behavior.
+  Date: 2026-07-15
+
+- Decision: Keep the historical MIT header on `src/test/runTest.ts` after the narrow test-runner changes.
+  Rationale: The file remains predominately 2019 TotalCross work; the import and environment sanitization are a minimal compatibility adjustment. The validator records it as historical work and preserves the existing MIT notice rather than asserting an unsupported whole-file relicensing.
   Date: 2026-07-15
 
 ## Outcomes & Retrospective

--- a/.agent/exec-plan-mit-to-apache-governance-refactor.md
+++ b/.agent/exec-plan-mit-to-apache-governance-refactor.md
@@ -51,13 +51,13 @@ The plan must not claim that code originally distributed under MIT retroactively
 - [x] (2026-07-15) Added `.github/workflows/governance-validation.yml` invoking the documented validator and test commands.
 - [x] (2026-07-15) Added historical MIT headers to 21 applicable `src/`, `resources/`, and shell files; generated Maven metadata remains untouched.
 - [x] (2026-07-15) Reviewed the governance diff; it contains attribution, licensing, planning, validation, CI, and header changes only.
-- [ ] Create the first governance commit.
-- [ ] Run the complete validation and focused build/test suite from the governance commit.
-- [ ] Inspect architecture, packages, modules, dependencies, naming, duplicated code, dead code, build structure, tests, and public APIs for refactoring opportunities.
-- [ ] Write proposed refactoring groups in `Decision Log` before changing code.
-- [ ] Implement refactoring in logical, independently buildable commits.
-- [ ] After each refactoring commit, run the smallest sufficient validation set and record meaningful findings.
-- [ ] Run the full supported build and test suite after the final refactoring commit.
+- [x] (2026-07-15) Created governance commit `ca549be` (`chore(governance): migrate project licensing to Apache-2.0`).
+- [x] (2026-07-15) Ran governance validation and 14 focused tests from the governance baseline; compile failure was isolated to a resolved `@types/vscode` version incompatible with TypeScript 3.9.10, before project source compilation.
+- [x] (2026-07-15) Inspected module sizes, package boundaries, build configuration, dependencies, source/test layout, public extension entry points, and obvious sensitive logging. The only safe, independently testable change within scope is deterministic type dependency resolution.
+- [x] (2026-07-15) Recorded the build dependency refactoring group before changing it.
+- [x] (2026-07-15) Implemented the build dependency refactoring by pinning `@types/vscode` to 1.40.0; `npm run compile`, governance validation, and 14 governance unit tests pass.
+- [x] (2026-07-15) Ran focused validation for the build dependency refactoring; no source or public API behavior changed.
+- [x] (2026-07-15) Ran the full supported `npm test` suite successfully after recompilation; it downloaded and launched VS Code 1.129.0 through `vscode-test`.
 - [ ] Review the final commit sequence for accidental mixing of governance and implementation work.
 - [ ] Complete `Outcomes & Retrospective` with counts, commands, commit hashes, exceptions, and follow-up items.
 
@@ -161,6 +161,10 @@ Do not silently resolve legal, attribution, or historical ambiguity. Record the 
 
 - Decision: Defer the TypeScript/@types VS Code compatibility repair to a post-governance build refactoring commit.
   Rationale: The failure is pre-existing dependency-resolution drift caused by the unpinned development dependency range, not a licensing or attribution change. Keeping it separate preserves the reviewable governance baseline.
+  Date: 2026-07-15
+
+- Decision: Pin `@types/vscode` to `1.40.0` in a standalone `refactor(build)` commit, while retaining the established TypeScript `^3.6.4` range.
+  Rationale: The extension declares VS Code engine `^1.40.0`; the old caret on its corresponding type definitions resolved to 1.125.0, whose declarations cannot be parsed by the resolved TypeScript 3.9.10 compiler. The exact historical API type package restores a reproducible compatible bound without changing runtime dependencies or extension behavior.
   Date: 2026-07-15
 
 ## Outcomes & Retrospective

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda.
+# SPDX-License-Identifier: Apache-2.0
+
+* @flsobral

--- a/.github/workflows/governance-validation.yml
+++ b/.github/workflows/governance-validation.yml
@@ -12,8 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+      - run: npm ci --ignore-scripts
+      - run: npm run audit
       - run: python3 tools/check-repository-governance.py
       - run: python3 -m unittest tests.test_repository_governance

--- a/.github/workflows/governance-validation.yml
+++ b/.github/workflows/governance-validation.yml
@@ -1,0 +1,19 @@
+# Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Governance validation
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  governance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: python3 tools/check-repository-governance.py
+      - run: python3 -m unittest tests.test_repository_governance

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 out
 node_modules
+__pycache__/
 .vscode-test/
 *.vsix

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,8 @@ The TypeScript extension is in `src/`; historical project templates are in
 `resources/`. Use `npm run compile` to type-check and compile, `npm test` for
 the VS Code integration suite, `python3 tools/check-repository-governance.py`
 for repository governance checks, and `python3 -m unittest
-tests.test_repository_governance` for the validator tests. Prefer focused
+tests.test_repository_governance` for the validator tests. Use `npm run audit`
+to verify the committed dependency graph. Prefer focused
 checks first and keep verbose output in a log when useful.
 
 Preserve historical TotalCross MIT notices and all third-party, generated, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+<!--
+Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Repository instructions for coding agents
+
+Fabio Sobral is the sole current maintainer.
+
+Before editing, read this file and `.agent/PLANS.md`, inspect `git status
+--short --branch`, and locate any applicable nested instructions. Keep an
+active ExecPlan current for long or multi-step work.
+
+The TypeScript extension is in `src/`; historical project templates are in
+`resources/`. Use `npm run compile` to type-check and compile, `npm test` for
+the VS Code integration suite, `python3 tools/check-repository-governance.py`
+for repository governance checks, and `python3 -m unittest
+tests.test_repository_governance` for the validator tests. Prefer focused
+checks first and keep verbose output in a log when useful.
+
+Preserve historical TotalCross MIT notices and all third-party, generated, and
+separately licensed notices. New first-party source uses the Amalgam
+Apache-2.0 header unless a documented exception applies. Never publish the
+obsolete former project contact address; report provenance or licensing
+ambiguity instead of guessing.
+
+For governance-only work, do not mix in broad formatting or implementation
+refactoring. Keep commits logical, narrowly described, and buildable whenever
+practical. Do not rewrite history, force-push, delete tags, or change release
+artifacts without explicit authorization.

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,33 @@
+<!--
+Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Authors and contributors
+
+## Original creator
+
+Italo Yeltsin ([@ItaloYeltsin](https://github.com/ItaloYeltsin))
+
+## Current maintainer
+
+Fabio Sobral ([@flsobral](https://github.com/flsobral))
+
+Fabio Sobral is the sole current maintainer.
+
+## Historical contributors
+
+- Allan C ([@acmlira](https://github.com/acmlira))
+- lucasgalvanini ([@lucasgalvanini](https://github.com/lucasgalvanini))
+- [@nmarquesin](https://github.com/nmarquesin)
+- Ricardo Braga ([@ricardobna](https://github.com/ricardobna))
+
+Additional contributions and the authoritative commit identity history are
+recorded in Git.
+
+## Copyright history
+
+- 2020-2021: TotalCross Global Mobile Platform Ltda., for applicable original
+  work under MIT notices.
+- 2022-2026: Amalgam Solucoes em TI Ltda., for applicable later work under
+  Apache-2.0 notices.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,7 @@ Run these commands from the repository root before opening a pull request:
 
     python3 tools/check-repository-governance.py
     python3 -m unittest tests.test_repository_governance
+    npm run audit
     npm run compile
 
 Run `npm test` when the VS Code integration-test prerequisites are available.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+<!--
+Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Contributing
+
+Fabio Sobral is the sole current maintainer and reviewer of record. Open a
+focused pull request with one coherent purpose and a concise commit message.
+
+## License and notices
+
+New first-party source files must use the Amalgam Apache-2.0 header:
+
+    Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda.
+    SPDX-License-Identifier: Apache-2.0
+
+Use the comment syntax appropriate for the file, preserving a shebang or XML
+declaration as the first line. Do not remove or rewrite historical TotalCross
+MIT notices, third-party notices, generated artifacts, or separately licensed
+content. If a file has mixed provenance or an unclear owner, stop and document
+the uncertainty for maintainer review rather than guessing.
+
+Contributions are expected to be offered under Apache License 2.0 for the new
+work they add, except where a documented historical or third-party license
+requires another treatment. This repository does not assert a contributor
+license agreement or copyright assignment.
+
+## Local checks
+
+Run these commands from the repository root before opening a pull request:
+
+    python3 tools/check-repository-governance.py
+    python3 -m unittest tests.test_repository_governance
+    npm run compile
+
+Run `npm test` when the VS Code integration-test prerequisites are available.
+The governance validator is read-only and uses only tracked files. Generated
+files must be changed through their generator when one exists.
+
+## Commit expectations
+
+Keep commits narrow, buildable where practical, and free of unrelated
+formatting sweeps. Run focused checks before expensive full builds, inspect
+`git diff --check`, and include any required test, import, configuration, and
+documentation changes in the same coherent commit.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2019 TotalCross Global Mobile Platform
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,12 @@
+TotalCross VS Code Extension
+
+Original project creation: Italo Yeltsin (@ItaloYeltsin).
+Current maintenance: Fabio Sobral (@flsobral), the sole current maintainer.
+
+Applicable original work from 2020-2021 is copyrighted by TotalCross Global
+Mobile Platform Ltda. and retains its historical MIT licensing notices.
+Applicable work from 2022-2026 is copyrighted by Amalgam Solucoes em TI Ltda.
+and is licensed under Apache License 2.0 unless a file states otherwise.
+
+Third-party, vendored, generated, and separately licensed materials retain
+their authoritative notices and licenses.

--- a/README.md
+++ b/README.md
@@ -1,83 +1,55 @@
-<div align="center"> <a href="https://totalcross.com/" target="_blank"> <img src="./totalcross.gif" alt="totalcross logo"/></a></div>
+# TotalCross VS Code Extension
 
-<div align="center"> 
-<h1>TotalCross Plugin</h1> </div>
-<p align="center">The simplest way to start coding with TotalCross</strong></em></p>
-
-TotalCross is an open source cross-platform SDK developed to bring speed to GUI (Graphical User Interface) creation for embedded devices. TotalCross has the development benefits from Java without the need of Java running on the device, as it uses its own bytecode and virtual machine (TC bytecode and TCVM), created specifically for performance enhancement. TotalCross runtime is currently at 5MB to bring mobile grade user experience even for low-end MPUs.
-
-## Features
-
-- Create a new project;
-- Package;
-- Deploy;
-- Deploy&Run (-linux_arm only via SSH).
+This extension adds commands to Visual Studio Code for creating, packaging,
+deploying, and deploying-and-running TotalCross projects. Deploy-and-run is
+currently intended for Linux ARM targets reached over SSH.
 
 ## Requirements
 
-- Java JDK 11 | [offical](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html) | [azul openjdk](https://www.azul.com/downloads/zulu-community/?version=java-11-lts&architecture=x86-64-bit&package=jdk) |
-- Maven 3.6.2 | [download](https://maven.apache.org/download.cgi) | [how to install](https://maven.apache.org/install.html) |
+- Java JDK 11
+- Maven 3.6.2
+- Node.js and npm compatible with this extension's dependencies
 
-## Using TotalCross Plugin
+## Use
 
-### Create a project
+Open the Command Palette (`F1` or `Cmd+Shift+P`) and select one of these
+commands:
 
-This is the first step you will need to follow.
+- `TotalCross: Create new Project`
+- `TotalCross: Package`
+- `TotalCross: Deploy`
+- `TotalCross: Deploy&Run`
 
-- Press `F1` or `cmd + shift + p` and search for `Totalcross: Create new Project`.
+Packaging places the target program in `target/install/<platform>`.
 
-![alt text](https://i.imgur.com/rli4Qsc.gif)
+## Development
 
-Now you can start coding your project.
+From the repository root, run:
 
-### Package
+    npm install
+    npm run compile
+    python3 tools/check-repository-governance.py
+    python3 -m unittest tests.test_repository_governance
 
-Once your project is finished, it's time to package it. This is how you do it:
+`npm test` runs the extension integration tests after compilation. It may
+download and start a compatible VS Code test instance.
 
-- Press `F1` or `cmd + shift + p` and search for `Totalcross: Package`;
-- The target program will take place inside the folder `target/install/<platform>`.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution and validation rules.
 
-![alt text](https://i.imgur.com/dIIZe1X.gif)
+## Authors and maintenance
 
-### Deploy
+The original creator is [Italo Yeltsin](https://github.com/ItaloYeltsin).
+[Fabio Sobral](https://github.com/flsobral) is the sole current maintainer.
+Historical contributors are listed in [AUTHORS.md](AUTHORS.md).
 
-- Press `F1` or `cmd + shift + p` and search for `Totalcross: Deploy`;
-- Fill in the device information.
-- See the result on the screen or with VNC.
+## License and transition
 
-![alt text](deployplugin.gif)
+The repository's current license is [Apache License 2.0](LICENSE). Versions
+and source distributions released before this governance change may remain
+available under the MIT License terms that accompanied them. From this
+governance change onward, project work controlled by the current copyright
+holder is licensed under the Apache License, Version 2.0, unless a file states
+otherwise.
 
-### Deploy and Run
-
-This is working only for linux arm programs. This feature performs platform _deploy&run_ via ssh.
-
-- Press `F1` or `cmd + shift + p` and search for `Totalcross: Deploy&Run`.
-
-![alt text](https://i.imgur.com/Y6F3pTc.gif)
-
-## Contributing to TotalCross Plugin
-
-To contribute, follow these steps:
-
-1. Fork this repository.
-2. Create a branch: `git checkout -b <branch_name>`.
-3. Make your changes and commit them: `git commit -m '<commit_message>'`
-4. Push to the original branch: `git push origin <project_name>/<location>`
-5. Create the pull request.
-
-## Mainteners
-
-Thanks to the following people who have contributed to this project:
-
-- [@ItaloYeltsin](https://github.com/ItaloYeltsin) 💻
-- [@acmlira](https://github.com/acmlira) 💻
-- [@ricardobna](https://github.com/ricardobna) 💻
-- [@nmarquesin](https://github.com/nmarquesin) 📖
-
-## Contact
-
-If you want to contact me you can reach me at br.yeltsin@gmail.com.
-
-## License
-
-This project uses the following license: [MIT](LICENSE).
+Historical TotalCross source files retain their MIT notices and licensing.
+See [NOTICE](NOTICE) for attribution and provenance details.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Packaging places the target program in `target/install/<platform>`.
 
 From the repository root, run:
 
-    npm install
+    npm ci
+    npm run audit
     npm run compile
     python3 tools/check-repository-governance.py
     python3 -m unittest tests.test_repository_governance

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2239 @@
+{
+	"name": "vscode-totalcross",
+	"version": "0.0.15",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "vscode-totalcross",
+			"version": "0.0.15",
+			"dependencies": {
+				"child_process": "^1.0.2",
+				"env-paths": "^2.2.0",
+				"fs-extra": "^8.1.0",
+				"jsonfile": "^6.0.1",
+				"node-ssh": "^13.2.1",
+				"replace-in-file": "^4.2.0",
+				"xml-js": "^1.6.11"
+			},
+			"devDependencies": {
+				"@types/glob": "^7.1.1",
+				"@types/mocha": "^10.0.10",
+				"@types/node": "^12.11.7",
+				"@types/vscode": "1.40.0",
+				"@vscode/test-electron": "^2.5.2",
+				"glob": "^7.1.5",
+				"mocha": "^11.7.6",
+				"typescript": "^3.6.4"
+			},
+			"engines": {
+				"vscode": "^1.40.0"
+			}
+		},
+		"node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@isaacs/cliui/node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@types/glob": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/minimatch": "*",
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/minimatch": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+			"integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/mocha": {
+			"version": "10.0.10",
+			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+			"integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "12.20.55",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+			"integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/vscode": {
+			"version": "1.40.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.40.0.tgz",
+			"integrity": "sha512-5kEIxL3qVRkwhlMerxO7XuMffa+0LBl+iG2TcRa0NsdoeSFLkt/9hJ02jsi/Kvc6y8OVF2N2P2IHP5S4lWf/5w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@vscode/test-electron": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
+			"integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"http-proxy-agent": "^7.0.2",
+				"https-proxy-agent": "^7.0.5",
+				"jszip": "^3.10.1",
+				"ora": "^8.1.0",
+				"semver": "^7.6.2"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@vscode/test-electron/node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@vscode/test-electron/node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@vscode/test-electron/node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@vscode/test-electron/node_modules/semver": {
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/asn1": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+			"integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": "~2.1.0"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"license": "MIT"
+		},
+		"node_modules/bcrypt-pbkdf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tweetnacl": "^0.14.3"
+			}
+		},
+		"node_modules/brace-expansion": {
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/browser-stdout": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/buildcheck": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+			"integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+			"optional": true,
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/chalk/node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/child_process": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
+			"integrity": "sha512-Wmza/JzL0SiWz7kl6MhIKT5ceIlnFPJX+lwUGj7Clhy5MMldsSoJR0+uvRzOS5Kv45Mq7t1PoE8TsOA9bzvb6g==",
+			"license": "ISC"
+		},
+		"node_modules/chokidar": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"readdirp": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14.16.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/cli-cursor": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+			"integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"restore-cursor": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cli-spinners": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+			"integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+			"license": "MIT"
+		},
+		"node_modules/concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"license": "MIT"
+		},
+		"node_modules/core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/cpu-features": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+			"integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+			"hasInstallScript": true,
+			"optional": true,
+			"dependencies": {
+				"buildcheck": "~0.0.6",
+				"nan": "^2.19.0"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/diff": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+			"integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
+		"node_modules/env-paths": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/flat": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"bin": {
+				"flat": "cli.js"
+			}
+		},
+		"node_modules/foreground-child": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.6",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=6 <7 || >=8"
+			}
+		},
+		"node_modules/fs-extra/node_modules/jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+			"license": "MIT",
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"license": "ISC"
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"license": "ISC",
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"license": "ISC"
+		},
+		"node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"he": "bin/he"
+			}
+		},
+		"node_modules/immediate": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+			"license": "ISC",
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"license": "ISC"
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-interactive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+			"integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-path-inside": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-plain-obj": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-unicode-supported": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+			"integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/jsonfile/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/jszip": {
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+			"integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+			"dev": true,
+			"license": "(MIT OR GPL-3.0-or-later)",
+			"dependencies": {
+				"lie": "~3.3.0",
+				"pako": "~1.0.2",
+				"readable-stream": "~2.3.6",
+				"setimmediate": "^1.0.5"
+			}
+		},
+		"node_modules/lie": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+			"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"immediate": "~3.0.5"
+			}
+		},
+		"node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/log-symbols": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^4.1.0",
+				"is-unicode-supported": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/log-symbols/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/log-symbols/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/log-symbols/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/log-symbols/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/log-symbols/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/log-symbols/node_modules/is-unicode-supported": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/log-symbols/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/make-dir": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/make-dir/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/mimic-function": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+			"integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/mocha": {
+			"version": "11.7.6",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
+			"integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"browser-stdout": "^1.3.1",
+				"chokidar": "^4.0.1",
+				"debug": "^4.3.5",
+				"diff": "^7.0.0",
+				"escape-string-regexp": "^4.0.0",
+				"find-up": "^5.0.0",
+				"glob": "^10.4.5",
+				"he": "^1.2.0",
+				"is-path-inside": "^3.0.3",
+				"js-yaml": "^4.1.0",
+				"log-symbols": "^4.1.0",
+				"minimatch": "^9.0.5",
+				"ms": "^2.1.3",
+				"picocolors": "^1.1.1",
+				"serialize-javascript": "^6.0.2",
+				"strip-json-comments": "^3.1.1",
+				"supports-color": "^8.1.1",
+				"workerpool": "^9.2.0",
+				"yargs": "^17.7.2",
+				"yargs-parser": "^21.1.1",
+				"yargs-unparser": "^2.0.0"
+			},
+			"bin": {
+				"_mocha": "bin/_mocha",
+				"mocha": "bin/mocha.js"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/mocha/node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true,
+			"license": "Python-2.0"
+		},
+		"node_modules/mocha/node_modules/brace-expansion": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/mocha/node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/mocha/node_modules/glob": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/mocha/node_modules/js-yaml": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/mocha/node_modules/minimatch": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/nan": {
+			"version": "2.28.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+			"integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/node-ssh": {
+			"version": "13.2.1",
+			"resolved": "https://registry.npmjs.org/node-ssh/-/node-ssh-13.2.1.tgz",
+			"integrity": "sha512-rfl4GWMygQfzlExPkQ2LWyya5n2jOBm5vhEnup+4mdw7tQhNpJWbP5ldr09Jfj93k5SfY5lxcn8od5qrQ/6mBg==",
+			"license": "MIT",
+			"dependencies": {
+				"is-stream": "^2.0.0",
+				"make-dir": "^3.1.0",
+				"sb-promise-queue": "^2.1.0",
+				"sb-scandir": "^3.1.0",
+				"shell-escape": "^0.2.0",
+				"ssh2": "^1.14.0"
+			},
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/onetime": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+			"integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-function": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ora": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+			"integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^5.3.0",
+				"cli-cursor": "^5.0.0",
+				"cli-spinners": "^2.9.2",
+				"is-interactive": "^2.0.0",
+				"is-unicode-supported": "^2.0.0",
+				"log-symbols": "^6.0.0",
+				"stdin-discarder": "^0.2.2",
+				"string-width": "^7.2.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ora/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/ora/node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/ora/node_modules/emoji-regex": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/ora/node_modules/log-symbols": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+			"integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^5.3.0",
+				"is-unicode-supported": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ora/node_modules/log-symbols/node_modules/is-unicode-supported": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+			"integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ora/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ora/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"license": "MIT",
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-locate/node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0"
+		},
+		"node_modules/pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+			"dev": true,
+			"license": "(MIT AND Zlib)"
+		},
+		"node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/readable-stream/node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/readable-stream/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/readdirp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.18.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/replace-in-file": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-4.3.1.tgz",
+			"integrity": "sha512-FqVvfmpqGTD2JRGI1JjJ86b24P17x/WWwGdxExeyJxnh/2rVQz2+jXfD1507UnnhEQw092X0u0DPCBf1WC4ooQ==",
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^2.4.2",
+				"glob": "^7.1.6",
+				"yargs": "^15.0.2"
+			},
+			"bin": {
+				"replace-in-file": "bin/cli.js"
+			}
+		},
+		"node_modules/replace-in-file/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/replace-in-file/node_modules/cliui": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+			"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^6.2.0"
+			}
+		},
+		"node_modules/replace-in-file/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/replace-in-file/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"license": "MIT"
+		},
+		"node_modules/replace-in-file/node_modules/find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/replace-in-file/node_modules/locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/replace-in-file/node_modules/p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/replace-in-file/node_modules/wrap-ansi": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/replace-in-file/node_modules/yargs": {
+			"version": "15.4.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^6.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^4.1.0",
+				"get-caller-file": "^2.0.1",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^2.0.0",
+				"set-blocking": "^2.0.0",
+				"string-width": "^4.2.0",
+				"which-module": "^2.0.0",
+				"y18n": "^4.0.0",
+				"yargs-parser": "^18.1.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/replace-in-file/node_modules/yargs-parser": {
+			"version": "18.1.3",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+			"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+			"license": "ISC",
+			"dependencies": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-main-filename": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+			"license": "ISC"
+		},
+		"node_modules/restore-cursor": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+			"integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"onetime": "^7.0.0",
+				"signal-exit": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"license": "MIT"
+		},
+		"node_modules/sax": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+			"integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=11.0.0"
+			}
+		},
+		"node_modules/sb-promise-queue": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/sb-promise-queue/-/sb-promise-queue-2.1.1.tgz",
+			"integrity": "sha512-qXfdcJQMxMljxmPprn4Q4hl3pJmoljSCzUvvEBa9Kscewnv56n0KqrO6yWSrGLOL9E021wcGdPa39CHGKA6G0w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/sb-scandir": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/sb-scandir/-/sb-scandir-3.1.1.tgz",
+			"integrity": "sha512-Q5xiQMtoragW9z8YsVYTAZcew+cRzdVBefPbb9theaIKw6cBo34WonP9qOCTKgyAmn/Ch5gmtAxT/krUgMILpA==",
+			"license": "MIT",
+			"dependencies": {
+				"sb-promise-queue": "^2.1.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/serialize-javascript": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+			"integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+			"license": "ISC"
+		},
+		"node_modules/setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shell-escape": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/shell-escape/-/shell-escape-0.2.0.tgz",
+			"integrity": "sha512-uRRBT2MfEOyxuECseCZd28jC1AJ8hmqqneWQ4VWUTgCAFvb3wKU1jLqj6egC4Exrr88ogg3dp+zroH4wJuaXzw==",
+			"license": "MIT"
+		},
+		"node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/ssh2": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+			"integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"asn1": "^0.2.6",
+				"bcrypt-pbkdf": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=10.16.0"
+			},
+			"optionalDependencies": {
+				"cpu-features": "~0.0.10",
+				"nan": "^2.23.0"
+			}
+		},
+		"node_modules/stdin-discarder": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+			"integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
+		"node_modules/string_decoder/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs": {
+			"name": "string-width",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/supports-color/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+			"license": "Unlicense"
+		},
+		"node_modules/typescript": {
+			"version": "3.9.10",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
+		"node_modules/universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/which-module": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+			"integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+			"license": "ISC"
+		},
+		"node_modules/workerpool": {
+			"version": "9.3.4",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+			"integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"license": "ISC"
+		},
+		"node_modules/xml-js": {
+			"version": "1.6.11",
+			"resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+			"integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+			"license": "MIT",
+			"dependencies": {
+				"sax": "^1.2.4"
+			},
+			"bin": {
+				"xml-js": "bin/cli.js"
+			}
+		},
+		"node_modules/y18n": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+			"license": "ISC"
+		},
+		"node_modules/yargs": {
+			"version": "17.7.3",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+			"integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yargs-unparser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+			"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"camelcase": "^6.0.0",
+				"decamelize": "^4.0.0",
+				"flat": "^5.0.2",
+				"is-plain-obj": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yargs-unparser/node_modules/camelcase": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/yargs-unparser/node_modules/decamelize": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+			"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/yargs/node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -51,18 +51,18 @@
 		"watch": "tsc -watch -p ./",
 		"validate:governance": "python3 tools/check-repository-governance.py",
 		"test:governance": "python3 -m unittest tests.test_repository_governance",
+		"audit": "npm audit --audit-level=low",
 		"pretest": "npm run compile",
 		"test": "node ./out/test/runTest.js"
 	},
 	"devDependencies": {
 		"@types/glob": "^7.1.1",
-		"@types/mocha": "^5.2.7",
+		"@types/mocha": "^10.0.10",
 		"@types/node": "^12.11.7",
 		"@types/vscode": "1.40.0",
 		"glob": "^7.1.5",
-		"mocha": "^6.2.2",
+		"mocha": "^11.7.6",
 		"typescript": "^3.6.4",
-		"tslint": "^5.20.0",
 		"@vscode/test-electron": "^2.5.2"
 	},
 	"dependencies": {
@@ -70,13 +70,15 @@
 		"env-paths": "^2.2.0",
 		"fs-extra": "^8.1.0",
 		"jsonfile": "^6.0.1",
-		"node-ssh": "^6.0.0",
-		"pom-parser": "^1.1.1",
+		"node-ssh": "^13.2.1",
 		"replace-in-file": "^4.2.0",
-		"request": "^2.88.2",
-		"request-promise": "^4.2.5",
-		"totalcross-core-dev": "^1.1.0",
 		"xml-js": "^1.6.11"
+	},
+	"overrides": {
+		"mocha": {
+			"diff": "8.0.3",
+			"serialize-javascript": "7.0.5"
+		}
 	},
 	"extensionDependencies": [
 		"vscjava.vscode-java-pack"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"@types/glob": "^7.1.1",
 		"@types/mocha": "^5.2.7",
 		"@types/node": "^12.11.7",
-		"@types/vscode": "^1.40.0",
+		"@types/vscode": "1.40.0",
 		"glob": "^7.1.5",
 		"mocha": "^6.2.2",
 		"typescript": "^3.6.4",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
 		"vscode:prepublish": "npm run compile",
 		"compile": "tsc -p ./",
 		"watch": "tsc -watch -p ./",
+		"validate:governance": "python3 tools/check-repository-governance.py",
+		"test:governance": "python3 -m unittest tests.test_repository_governance",
 		"pretest": "npm run compile",
 		"test": "node ./out/test/runTest.js"
 	},

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"mocha": "^6.2.2",
 		"typescript": "^3.6.4",
 		"tslint": "^5.20.0",
-		"vscode-test": "^1.2.2"
+		"@vscode/test-electron": "^2.5.2"
 	},
 	"dependencies": {
 		"child_process": "^1.0.2",

--- a/resources/Sample.java
+++ b/resources/Sample.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+ * SPDX-License-Identifier: MIT
+ */
+
 package ${'groupid'};
 import totalcross.ui.MainWindow;
 import totalcross.ui.Label;

--- a/resources/TestSampleApplication.java
+++ b/resources/TestSampleApplication.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+ * SPDX-License-Identifier: MIT
+ */
+
 package ${'groupid'};
 
 import totalcross.TotalCrossApplication;

--- a/resources/pom.xml
+++ b/resources/pom.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+  SPDX-License-Identifier: MIT
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/src/components/components.ts
+++ b/src/components/components.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as vscode from 'vscode';
 
 export function showInputBox(prompt: string, placeHolder: string, validator: any) {

--- a/src/config-checker.ts
+++ b/src/config-checker.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as vscode from 'vscode';
 import * as util from './util';
 import { pathToFileURL } from 'url';
@@ -70,5 +75,4 @@ export class ConfigChecker {
         return jsonfile.writeFileSync(this.path, data);
     }
 }
-
 

--- a/src/config-checker.ts
+++ b/src/config-checker.ts
@@ -7,7 +7,6 @@ import * as vscode from 'vscode';
 import * as util from './util';
 import { pathToFileURL } from 'url';
 const fs = require('fs-extra');
-const request = require('request-promise');
 const jsonfile = require('jsonfile');
 
 
@@ -75,4 +74,3 @@ export class ConfigChecker {
         return jsonfile.writeFileSync(this.path, data);
     }
 }
-

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as vscode from 'vscode';
 import {showInputBox} from './components/components';
 import { pathToFileURL } from 'url';

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -5,14 +5,10 @@
 
 import * as vscode from 'vscode';
 import {showInputBox} from './components/components';
-import { pathToFileURL } from 'url';
-import * as util from './util';
+import {latestMavenPluginVersion, latestTotalCrossSdkVersions} from './maven-metadata';
 
-const core = require('totalcross-core-dev');
 const validators = require('./validators/creator');
 const fs = require('fs-extra');
-const request = require('request');
-const xmlParser = require('xml-js');
 const replace = require('replace-in-file');
 
 const options: vscode.OpenDialogOptions = {
@@ -40,7 +36,7 @@ exports.createNewProject = async function(context: vscode.ExtensionContext) {
         validators.artifactId
         );
     if(!artifactID) {return;}
-    let availableVersions = await core.latestVersions(`${context.extensionPath}/resources/maven-metadata.xml`);
+    let availableVersions = await latestTotalCrossSdkVersions(`${context.extensionPath}/resources/maven-metadata.xml`);
     let version = await vscode.window.showQuickPick(availableVersions, {
         placeHolder: 'totalcross sdk version',
         ignoreFocusOut: true
@@ -60,7 +56,7 @@ exports.createNewProject = async function(context: vscode.ExtensionContext) {
     let activationKey = "5443444B5AAEEB90306B00E4";
     if(!activationKey) {return;}
     
-    let mavenPluginVersion = await core.mavenPluginLatestVersion();
+    let mavenPluginVersion = await latestMavenPluginVersion();
 
     let props = {artifactID, groupID, platforms, version, activationKey, mavenPluginVersion};
     let path = file[0].fsPath.toString();

--- a/src/deployer.ts
+++ b/src/deployer.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as vscode from 'vscode';
 var node_ssh = require('node-ssh');
 var validators = require('./validators/deployer');
@@ -130,4 +135,3 @@ exports.deployAndRun = async function() {
           });
     }
 };
-

--- a/src/deployer.ts
+++ b/src/deployer.ts
@@ -6,8 +6,9 @@
 import * as vscode from 'vscode';
 var node_ssh = require('node-ssh');
 var validators = require('./validators/deployer');
-const pomParser = require('pom-parser');
 const Packager = require('./packager');
+const fs = require('fs-extra');
+const xmlParser = require('xml-js');
 
 var ssh = new node_ssh();
 var folder: any;
@@ -15,6 +16,12 @@ var username: any;
 var host: any;
 var pom: any;
 var password: any;
+
+async function readPom(pomPath: string): Promise<any> {
+    const contents = await fs.readFile(pomPath, 'utf8');
+    return JSON.parse(xmlParser.xml2json(contents, {compact: true}));
+}
+
 exports.deploy = async function() {
     return new Promise(async function (resolve){
         let workspaceFolders = vscode.workspace.workspaceFolders;
@@ -25,11 +32,7 @@ exports.deploy = async function() {
     }
     let file = workspaceFolders[0].uri.fsPath + "/target/install/linux_arm";
     let pomPath = workspaceFolders[0].uri.fsPath + "/pom.xml";
-    pom = await new Promise(resolve2 => {
-        pomParser.parse({filePath: pomPath}, function(err: any, response: any) {
-            resolve2(response.pomObject);
-        });
-    });
+    pom = await readPom(pomPath);
     // ask user
     if(!username) {
         username = await vscode.window.showInputBox({
@@ -56,7 +59,6 @@ exports.deploy = async function() {
             prompt: 'host password',
             value: password === undefined ? undefined : password
         });
-        console.log(password);
     }
     // ask app folder
     // ask user

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+ * SPDX-License-Identifier: MIT
+ */
+
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';

--- a/src/maven-metadata.ts
+++ b/src/maven-metadata.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as https from 'https';
+
+const fs = require('fs-extra');
+const xmlParser = require('xml-js');
+
+const TOTALCROSS_SDK_METADATA_URL = 'https://maven.totalcross.com/artifactory/repo1/com/totalcross/totalcross-sdk/maven-metadata.xml';
+const TOTALCROSS_MAVEN_PLUGIN_METADATA_URL = 'https://maven.totalcross.com/artifactory/repo1/com/totalcross/totalcross-maven-plugin/maven-metadata.xml';
+
+export function metadataVersions(metadata: string): string[] {
+    const document = JSON.parse(xmlParser.xml2json(metadata, {compact: true}));
+    const versionNodes = document.metadata.versioning.versions.version;
+    const nodes = Array.isArray(versionNodes) ? versionNodes : [versionNodes];
+    return nodes
+        .map((version: any) => version._text)
+        .filter((version: any) => typeof version === 'string')
+        .sort()
+        .reverse();
+}
+
+export function latestVersionForEachMajor(versions: string[]): string[] {
+    return versions.filter((version, index) => index === 0 || version.split('.')[0] !== versions[index - 1].split('.')[0]);
+}
+
+function downloadText(url: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const request = https.get(url, (response) => {
+            if (!response.statusCode || response.statusCode >= 300) {
+                response.resume();
+                reject(new Error(`Unable to download Maven metadata: HTTP ${response.statusCode || 'unknown'}`));
+                return;
+            }
+            let contents = '';
+            response.setEncoding('utf8');
+            response.on('data', (chunk) => contents += chunk);
+            response.on('end', () => resolve(contents));
+        });
+        request.setTimeout(10000, () => request.destroy(new Error('Timed out downloading Maven metadata')));
+        request.on('error', reject);
+    });
+}
+
+export async function latestTotalCrossSdkVersions(cachedMetadataPath: string): Promise<string[]> {
+    try {
+        return latestVersionForEachMajor(metadataVersions(await downloadText(TOTALCROSS_SDK_METADATA_URL)));
+    } catch (_) {
+        return latestVersionForEachMajor(metadataVersions(await fs.readFile(cachedMetadataPath, 'utf8')));
+    }
+}
+
+export async function latestMavenPluginVersion(): Promise<string> {
+    return metadataVersions(await downloadText(TOTALCROSS_MAVEN_PLUGIN_METADATA_URL))[0];
+}

--- a/src/model/response.ts
+++ b/src/model/response.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+ * SPDX-License-Identifier: MIT
+ */
+
 export interface Response {
     error: boolean;
     message: any;

--- a/src/packager.ts
+++ b/src/packager.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as vscode from 'vscode';
 var output = vscode.window.createTerminal("TotalCross Packager");
 

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -5,7 +5,11 @@
 
 import * as path from 'path';
 
-import { runTests } from 'vscode-test';
+import { runTests } from '@vscode/test-electron';
+
+// A VS Code extension host sets this for Node-based extension processes. The
+// integration runner must launch the downloaded Electron application instead.
+delete process.env.ELECTRON_RUN_AS_NODE;
 
 async function main() {
 	try {

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as path from 'path';
 
 import { runTests } from 'vscode-test';

--- a/src/test/suite/config-checker.test.ts
+++ b/src/test/suite/config-checker.test.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as assert from 'assert';
 
 // You can import and use all API from the 'vscode' module
@@ -57,4 +62,3 @@ let nullInputProcessor = {
 	
 	
 // });
-

--- a/src/test/suite/create.test.ts
+++ b/src/test/suite/create.test.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as assert from 'assert';
 
 // You can import and use all API from the 'vscode' module
@@ -25,4 +30,3 @@ suite('Creator', () => {
 		// assert.notEqual(creatorValidator.groupId(''), null);
 	});
 });
-

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as assert from 'assert';
 
 // You can import and use all API from the 'vscode' module
@@ -13,4 +18,3 @@ suite('Extension Test Suite', () => {
 		assert.equal(-1, [1, 2, 3].indexOf(0));
 	});
 });
-

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as path from 'path';
 import * as Mocha from 'mocha';
 import * as glob from 'glob';

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -11,8 +11,8 @@ export function run(): Promise<void> {
 	// Create the mocha test
 	const mocha = new Mocha({
 		ui: 'tdd',
+		color: true,
 	});
-	mocha.useColors(true);
 
 	const testsRoot = path.resolve(__dirname, '..');
 

--- a/src/test/suite/maven-metadata.test.ts
+++ b/src/test/suite/maven-metadata.test.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert';
+import {latestVersionForEachMajor, metadataVersions} from '../../maven-metadata';
+
+suite('Maven metadata', () => {
+    test('sorts metadata versions and selects the latest version of each major', () => {
+        const metadata = `<?xml version="1.0"?>
+            <metadata><versioning><versions>
+              <version>5.1.3</version><version>6.0.2</version>
+              <version>5.0.0</version><version>6.0.1</version>
+            </versions></versioning></metadata>`;
+        const versions = metadataVersions(metadata);
+
+        assert.deepEqual(versions, ['6.0.2', '6.0.1', '5.1.3', '5.0.0']);
+        assert.deepEqual(latestVersionForEachMajor(versions), ['6.0.2', '5.1.3']);
+    });
+});

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+ * SPDX-License-Identifier: MIT
+ */
+
 const fs = require('fs-extra');
 const envPaths = require('env-paths');
 const paths = envPaths('TotalCross', {suffix: null});

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,7 +6,6 @@
 const fs = require('fs-extra');
 const envPaths = require('env-paths');
 const paths = envPaths('TotalCross', {suffix: null});
-const request = require('request-promise');
 
 
 export function getTotalCrossConfigHomePath() : string{

--- a/src/validators/creator.ts
+++ b/src/validators/creator.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as vscode from 'vscode';
 
 exports.groupId = function(value: string) {

--- a/src/validators/deployer.ts
+++ b/src/validators/deployer.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as vscode from 'vscode';
 
 exports.user = function(value: string) {

--- a/src/validators/login.ts
+++ b/src/validators/login.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+ * SPDX-License-Identifier: MIT
+ */
+
 export function validateLogin(value: string) {
         if(!value) {
             return 'Login cannot be empty!';

--- a/src/validators/register.ts
+++ b/src/validators/register.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { validatePassword } from "./login";
 
 export function validateNonEmpty(field: string) {
@@ -17,4 +22,4 @@ export function validateEmail(value: string) {
     return null;
 }
 
-exports.validatePassword = validatePassword; 
+exports.validatePassword = validatePassword;

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+# SPDX-License-Identifier: MIT
 
 code \
 --extensionDevelopmentPath=. \

--- a/tests/test_repository_governance.py
+++ b/tests/test_repository_governance.py
@@ -27,6 +27,7 @@ class RepositoryGovernanceTest(unittest.TestCase):
         self.write("AGENTS.md", html_header + "Fabio Sobral is the sole current maintainer.\n")
         self.write("NOTICE", "Italo Yeltsin\nFabio Sobral\nMIT\nApache\n")
         self.write("LICENSE", "Apache License\nVersion 2.0, January 2004\n")
+        self.write("package-lock.json", "{\"lockfileVersion\": 3, \"packages\": {}}\n")
         self.write(".agent/PLANS.md", html_header + "Outcomes & Retrospective\nEditorial Report\n")
         self.write(".github/CODEOWNERS", hash_header + "* @flsobral\n")
         self.write(".github/workflows/governance-validation.yml", hash_header + "name: test\n")
@@ -54,6 +55,10 @@ class RepositoryGovernanceTest(unittest.TestCase):
 
     def test_valid_amalgam_apache_header(self):
         errors = self.errors_for("tools/check-repository-governance.py", f"# {governance.AMALGAM_COPYRIGHT}\n# {governance.APACHE}\n")
+        self.assertEqual([], errors)
+
+    def test_new_amalgam_source_header_is_validated(self):
+        errors = self.errors_for("src/maven-metadata.ts", f"/*\n * {governance.AMALGAM_COPYRIGHT}\n * {governance.APACHE}\n */\n")
         self.assertEqual([], errors)
 
     def test_amalgam_mit_header_is_rejected(self):
@@ -100,6 +105,11 @@ class RepositoryGovernanceTest(unittest.TestCase):
         self.write("README.md", "The original creator is Italo Yeltsin. Fabio Sobral maintains this.\n")
         self.track()
         self.assertIn("README.md: must identify Fabio Sobral as sole current maintainer", governance.validate(self.root))
+
+    def test_invalid_lockfile_is_rejected(self):
+        self.write("package-lock.json", "not json\n")
+        self.track()
+        self.assertIn("package-lock.json: must be valid JSON", governance.validate(self.root))
 
     def test_diagnostics_are_sorted(self):
         self.write("src/z.ts", "")

--- a/tests/test_repository_governance.py
+++ b/tests/test_repository_governance.py
@@ -1,0 +1,123 @@
+# Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("governance", ROOT / "tools/check-repository-governance.py")
+governance = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(governance)
+
+
+class RepositoryGovernanceTest(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        self.write("README.md", "The original creator is Italo Yeltsin. Fabio Sobral is the sole current maintainer.\n")
+        html_header = f"<!--\n{governance.AMALGAM_COPYRIGHT}\n{governance.APACHE}\n-->\n"
+        hash_header = f"# {governance.AMALGAM_COPYRIGHT}\n# {governance.APACHE}\n"
+        self.write("AUTHORS.md", html_header + "## Original creator\nItalo Yeltsin\n## Current maintainer\nFabio Sobral is the sole current maintainer.\n")
+        self.write("CONTRIBUTING.md", html_header + "Apache-2.0\npython3 tools/check-repository-governance.py\n")
+        self.write("AGENTS.md", html_header + "Fabio Sobral is the sole current maintainer.\n")
+        self.write("NOTICE", "Italo Yeltsin\nFabio Sobral\nMIT\nApache\n")
+        self.write("LICENSE", "Apache License\nVersion 2.0, January 2004\n")
+        self.write(".agent/PLANS.md", html_header + "Outcomes & Retrospective\nEditorial Report\n")
+        self.write(".github/CODEOWNERS", hash_header + "* @flsobral\n")
+        self.write(".github/workflows/governance-validation.yml", hash_header + "name: test\n")
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def write(self, relative: str, contents: str):
+        target = self.root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(contents, encoding="utf-8")
+
+    def track(self):
+        subprocess.run(["git", "init", "-q", str(self.root)], check=True)
+        subprocess.run(["git", "-C", str(self.root), "add", "-A"], check=True)
+
+    def errors_for(self, relative: str, contents: str):
+        self.write(relative, contents)
+        self.track()
+        return governance.validate(self.root)
+
+    def test_valid_historical_mit_header(self):
+        errors = self.errors_for("src/example.ts", f"/*\n * {governance.HISTORICAL_COPYRIGHT}\n * {governance.MIT}\n */\nexport {{}};\n")
+        self.assertEqual([], errors)
+
+    def test_valid_amalgam_apache_header(self):
+        errors = self.errors_for("tools/check-repository-governance.py", f"# {governance.AMALGAM_COPYRIGHT}\n# {governance.APACHE}\n")
+        self.assertEqual([], errors)
+
+    def test_amalgam_mit_header_is_rejected(self):
+        errors = self.errors_for("tools/check-repository-governance.py", f"# {governance.AMALGAM_COPYRIGHT}\n# {governance.MIT}\n")
+        self.assertIn("tools/check-repository-governance.py: missing or misplaced required amalgam copyright/SPDX header", errors)
+        self.assertIn("tools/check-repository-governance.py: Amalgam-era first-party work must not use the MIT SPDX identifier", errors)
+
+    def test_valid_mixed_history_header(self):
+        contents = f"/*\n * {governance.HISTORICAL_COPYRIGHT}\n * {governance.AMALGAM_COPYRIGHT}\n * {governance.APACHE}\n */\n"
+        errors = self.errors_for("tests/fixtures/mixed-history/example.ts", contents)
+        self.assertEqual([], errors)
+
+    def test_missing_historical_notice_is_reported(self):
+        errors = self.errors_for("src/example.ts", f"/* {governance.MIT} */\n")
+        self.assertIn("src/example.ts: missing or misplaced required historical copyright/SPDX header", errors)
+
+    def test_historical_apache_header_is_rejected(self):
+        errors = self.errors_for("src/example.ts", f"/*\n * {governance.HISTORICAL_COPYRIGHT}\n * {governance.APACHE}\n */\n")
+        self.assertIn("src/example.ts: missing or misplaced required historical copyright/SPDX header", errors)
+        self.assertIn("src/example.ts: historical TotalCross work must retain its MIT SPDX identifier", errors)
+
+    def test_wrong_owner_and_year_is_reported(self):
+        errors = self.errors_for("src/example.ts", f"/*\n * {governance.AMALGAM_COPYRIGHT}\n * {governance.MIT}\n */\n")
+        self.assertIn("src/example.ts: missing or misplaced required historical copyright/SPDX header", errors)
+
+    def test_obsolete_contact_is_reported(self):
+        email = "br.yeltsin" + "@gmail.com"
+        errors = self.errors_for("README.md", f"The original creator is Italo Yeltsin. Fabio Sobral is the sole current maintainer. {email}\n")
+        self.assertIn("README.md: contains obsolete project contact information", errors)
+
+    def test_generated_and_third_party_exclusions_are_not_checked(self):
+        email = "br.yeltsin" + "@gmail.com"
+        self.write("resources/maven-metadata.xml", email)
+        self.write("vsc-extension-quickstart.md", email)
+        self.track()
+        self.assertEqual([], governance.validate(self.root))
+
+    def test_itolo_as_current_maintainer_is_rejected(self):
+        self.write("AUTHORS.md", f"<!--\n{governance.AMALGAM_COPYRIGHT}\n{governance.APACHE}\n-->\n## Original creator\nItalo Yeltsin\n## Current maintainer\nItalo Yeltsin\n")
+        self.track()
+        self.assertIn("AUTHORS.md: must identify Fabio Sobral as sole current maintainer", governance.validate(self.root))
+
+    def test_fabio_missing_as_sole_current_maintainer_is_rejected(self):
+        self.write("README.md", "The original creator is Italo Yeltsin. Fabio Sobral maintains this.\n")
+        self.track()
+        self.assertIn("README.md: must identify Fabio Sobral as sole current maintainer", governance.validate(self.root))
+
+    def test_diagnostics_are_sorted(self):
+        self.write("src/z.ts", "")
+        self.write("src/a.ts", "")
+        self.track()
+        errors = governance.validate(self.root)
+        self.assertEqual(sorted(errors), errors)
+
+    def test_path_with_space_is_validated(self):
+        errors = self.errors_for("src/path with space.ts", f"/*\n * {governance.HISTORICAL_COPYRIGHT}\n * {governance.MIT}\n */\n")
+        self.assertEqual([], errors)
+
+    def test_shebang_and_xml_declaration_placement(self):
+        self.write("test.sh", f"#!/usr/bin/env bash\n# {governance.HISTORICAL_COPYRIGHT}\n# {governance.MIT}\n")
+        self.write("resources/template.xml", f"<?xml version=\"1.0\"?>\n<!--\n  {governance.HISTORICAL_COPYRIGHT}\n  {governance.MIT}\n-->\n")
+        self.track()
+        self.assertEqual([], governance.validate(self.root))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check-repository-governance.py
+++ b/tools/check-repository-governance.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -20,6 +21,8 @@ OBSOLETE_EMAIL = "br.yeltsin" + "@gmail.com"
 HISTORICAL_PATHS = ("src/", "resources/")
 HISTORICAL_EXCLUSIONS = {"resources/maven-metadata.xml"}
 AMALGAM_C_PATHS = {
+    "src/maven-metadata.ts",
+    "src/test/suite/maven-metadata.test.ts",
     "tools/check-repository-governance.py",
     "tests/test_repository_governance.py",
 }
@@ -51,10 +54,10 @@ def classify(path: str) -> str:
         return "mixed"
     if path in EXCLUDED_PATHS or path in HISTORICAL_EXCLUSIONS or path.startswith(EXCLUDED_PREFIXES):
         return "excluded"
-    if path == "test.sh" or (path.startswith(HISTORICAL_PATHS) and path not in HISTORICAL_EXCLUSIONS):
-        return "historical"
     if path in AMALGAM_C_PATHS or path in AMALGAM_HASH_PATHS or path in AMALGAM_HTML_PATHS:
         return "amalgam"
+    if path == "test.sh" or (path.startswith(HISTORICAL_PATHS) and path not in HISTORICAL_EXCLUSIONS):
+        return "historical"
     return "metadata"
 
 
@@ -99,6 +102,7 @@ def validate_metadata(root: Path, paths: list[str]) -> list[str]:
         "AGENTS.md",
         "NOTICE",
         "LICENSE",
+        "package-lock.json",
         ".agent/PLANS.md",
         ".github/CODEOWNERS",
         ".github/workflows/governance-validation.yml",
@@ -114,6 +118,7 @@ def validate_metadata(root: Path, paths: list[str]) -> list[str]:
     contributing = read_text(root, "CONTRIBUTING.md")
     notice = read_text(root, "NOTICE")
     license_text = read_text(root, "LICENSE")
+    lockfile = read_text(root, "package-lock.json")
     codeowners = read_text(root, ".github/CODEOWNERS")
     plans = read_text(root, ".agent/PLANS.md")
     if "original creator" not in readme.lower() or "Italo Yeltsin" not in readme:
@@ -132,6 +137,11 @@ def validate_metadata(root: Path, paths: list[str]) -> list[str]:
         errors.append("NOTICE: must preserve required attribution and transition information")
     if "Apache License" not in license_text or "Version 2.0, January 2004" not in license_text:
         errors.append("LICENSE: must contain the complete Apache License 2.0 text")
+    try:
+        if not isinstance(json.loads(lockfile).get("lockfileVersion"), int):
+            errors.append("package-lock.json: must be a valid npm lockfile")
+    except ValueError:
+        errors.append("package-lock.json: must be valid JSON")
     if "* @flsobral" not in codeowners:
         errors.append(".github/CODEOWNERS: must assign the default owner to @flsobral")
     if "Editorial Report" not in plans or "Outcomes & Retrospective" not in plans:

--- a/tools/check-repository-governance.py
+++ b/tools/check-repository-governance.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate tracked governance metadata and first-party license headers."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+HISTORICAL_COPYRIGHT = "Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda."
+AMALGAM_COPYRIGHT = "Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda."
+MIT = "SPDX-License-Identifier: MIT"
+APACHE = "SPDX-License-Identifier: Apache-2.0"
+OBSOLETE_EMAIL = "br.yeltsin" + "@gmail.com"
+
+HISTORICAL_PATHS = ("src/", "resources/")
+HISTORICAL_EXCLUSIONS = {"resources/maven-metadata.xml"}
+AMALGAM_C_PATHS = {
+    "tools/check-repository-governance.py",
+    "tests/test_repository_governance.py",
+}
+AMALGAM_HASH_PATHS = {
+    ".github/CODEOWNERS",
+    ".github/workflows/governance-validation.yml",
+}
+AMALGAM_HTML_PATHS = {"AGENTS.md", "AUTHORS.md", "CONTRIBUTING.md", ".agent/PLANS.md"}
+MIXED_FIXTURE_PREFIX = "tests/fixtures/mixed-history/"
+EXCLUDED_PREFIXES = (".git/", "out/", "node_modules/", "tests/fixtures/")
+EXCLUDED_PATHS = {
+    ".github/modernize/java-upgrade/.gitignore",
+    "vsc-extension-quickstart.md",
+}
+
+
+def tracked_paths(root: Path) -> list[str]:
+    result = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return sorted(path for path in result.stdout.decode("utf-8").split("\0") if path)
+
+
+def classify(path: str) -> str:
+    if path.startswith(MIXED_FIXTURE_PREFIX):
+        return "mixed"
+    if path in EXCLUDED_PATHS or path in HISTORICAL_EXCLUSIONS or path.startswith(EXCLUDED_PREFIXES):
+        return "excluded"
+    if path == "test.sh" or (path.startswith(HISTORICAL_PATHS) and path not in HISTORICAL_EXCLUSIONS):
+        return "historical"
+    if path in AMALGAM_C_PATHS or path in AMALGAM_HASH_PATHS or path in AMALGAM_HTML_PATHS:
+        return "amalgam"
+    return "metadata"
+
+
+def read_text(root: Path, path: str) -> str:
+    return (root / path).read_text(encoding="utf-8", errors="replace")
+
+
+def expected_header(path: str, category: str) -> tuple[str, str] | None:
+    if category == "historical":
+        return HISTORICAL_COPYRIGHT, MIT
+    if category == "mixed":
+        return AMALGAM_COPYRIGHT, APACHE
+    if category == "amalgam":
+        return AMALGAM_COPYRIGHT, APACHE
+    return None
+
+
+def header_is_placed_correctly(path: str, contents: str, category: str) -> bool:
+    first, second = expected_header(path, category) or ("", "")
+    lines = contents.splitlines()
+    if path.endswith(".xml"):
+        header = "\n".join(lines[1:6])
+        return len(lines) >= 4 and lines[0].startswith("<?xml") and first in header and second in header
+    if path.endswith(".sh"):
+        header = "\n".join(lines[1:5])
+        return len(lines) >= 3 and lines[0].startswith("#!") and first in header and second in header
+    early_contents = "\n".join(lines[:9])
+    return first in early_contents and second in early_contents
+
+
+def has_spdx_header(contents: str, identifier: str) -> bool:
+    return any(line.lstrip("# /*\t").strip() == identifier for line in contents.splitlines())
+
+
+def validate_metadata(root: Path, paths: list[str]) -> list[str]:
+    errors: list[str] = []
+    present = set(paths)
+    required = {
+        "README.md",
+        "AUTHORS.md",
+        "CONTRIBUTING.md",
+        "AGENTS.md",
+        "NOTICE",
+        "LICENSE",
+        ".agent/PLANS.md",
+        ".github/CODEOWNERS",
+        ".github/workflows/governance-validation.yml",
+    }
+    for path in sorted(required - present):
+        errors.append(f"{path}: required governance file is not tracked")
+    if required - present:
+        return errors
+
+    readme = read_text(root, "README.md")
+    authors = read_text(root, "AUTHORS.md")
+    agents = read_text(root, "AGENTS.md")
+    contributing = read_text(root, "CONTRIBUTING.md")
+    notice = read_text(root, "NOTICE")
+    license_text = read_text(root, "LICENSE")
+    codeowners = read_text(root, ".github/CODEOWNERS")
+    plans = read_text(root, ".agent/PLANS.md")
+    if "original creator" not in readme.lower() or "Italo Yeltsin" not in readme:
+        errors.append("README.md: must identify Italo Yeltsin as original creator")
+    if "Fabio Sobral" not in readme or "sole current maintainer" not in readme:
+        errors.append("README.md: must identify Fabio Sobral as sole current maintainer")
+    if "## Original creator" not in authors or "Italo Yeltsin" not in authors:
+        errors.append("AUTHORS.md: must identify Italo Yeltsin as original creator")
+    if "## Current maintainer" not in authors or "Fabio Sobral is the sole current maintainer." not in authors:
+        errors.append("AUTHORS.md: must identify Fabio Sobral as sole current maintainer")
+    if "Fabio Sobral is the sole current maintainer" not in agents:
+        errors.append("AGENTS.md: must identify Fabio Sobral as sole current maintainer")
+    if "Apache-2.0" not in contributing or "python3 tools/check-repository-governance.py" not in contributing:
+        errors.append("CONTRIBUTING.md: must document Apache-2.0 and the governance command")
+    if "Italo Yeltsin" not in notice or "Fabio Sobral" not in notice or "MIT" not in notice or "Apache" not in notice:
+        errors.append("NOTICE: must preserve required attribution and transition information")
+    if "Apache License" not in license_text or "Version 2.0, January 2004" not in license_text:
+        errors.append("LICENSE: must contain the complete Apache License 2.0 text")
+    if "* @flsobral" not in codeowners:
+        errors.append(".github/CODEOWNERS: must assign the default owner to @flsobral")
+    if "Editorial Report" not in plans or "Outcomes & Retrospective" not in plans:
+        errors.append(".agent/PLANS.md: must define complete ExecPlan requirements")
+    return errors
+
+
+def validate(root: Path) -> list[str]:
+    paths = tracked_paths(root)
+    errors = validate_metadata(root, paths)
+    for path in paths:
+        category = classify(path)
+        if category == "excluded":
+            continue
+        contents = read_text(root, path)
+        if OBSOLETE_EMAIL in contents:
+            errors.append(f"{path}: contains obsolete project contact information")
+        expected = expected_header(path, category)
+        if expected and not header_is_placed_correctly(path, contents, category):
+            errors.append(f"{path}: missing or misplaced required {category} copyright/SPDX header")
+        if category == "historical" and has_spdx_header(contents, APACHE):
+            errors.append(f"{path}: historical TotalCross work must retain its MIT SPDX identifier")
+        if category == "amalgam" and has_spdx_header(contents, MIT):
+            errors.append(f"{path}: Amalgam-era first-party work must not use the MIT SPDX identifier")
+        if category == "mixed" and (HISTORICAL_COPYRIGHT not in contents or AMALGAM_COPYRIGHT not in contents):
+            errors.append(f"{path}: mixed-history work must retain both copyright statements")
+    return sorted(errors)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    args = parser.parse_args()
+    try:
+        errors = validate(args.root.resolve())
+    except subprocess.CalledProcessError as error:
+        sys.stderr.write(error.stderr.decode("utf-8", errors="replace"))
+        return 2
+    if errors:
+        print("Repository governance validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("Repository governance validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- Migrates current repository governance to Apache-2.0 while preserving historical TotalCross MIT notices and attribution.
- Adds repository governance validation, agent guidance, CI checks, and a reproducible npm lockfile.
- Restores build and VS Code integration-test compatibility.
- Removes vulnerable request-based dependencies and updates the audited dependency graph.

## Why

The repository had outdated licensing metadata, non-reproducible dependency resolution, and 17 npm audit findings, including critical issues in the abandoned request stack.

## Validation

- `npm ci --ignore-scripts`
- `npm run audit` (0 vulnerabilities)
- `npm run compile`
- `python3 tools/check-repository-governance.py`
- `python3 -m unittest tests.test_repository_governance` (16 tests)
- `npm test` (3 passing extension tests)
